### PR TITLE
fix: await compile hooks when build

### DIFF
--- a/packages/ice/src/commands/build.ts
+++ b/packages/ice/src/commands/build.ts
@@ -19,7 +19,7 @@ const build = async (context: Context<Config>, contextConfig: ContextConfig[], e
     applyHook,
     esbuildCompile,
   });
-  await new Promise((resolve, reject): void => {
+  const { stats, isSuccessful, messages } = await new Promise((resolve, reject): void => {
     let messages: { errors: string[]; warnings: string[] };
     compiler.run((err, stats) => {
       if (err) {
@@ -41,11 +41,21 @@ const build = async (context: Context<Config>, contextConfig: ContextConfig[], e
         return;
       } else {
         compiler?.close?.(() => {});
+        const isSuccessful = !messages.errors.length && !messages.warnings.length;
         resolve({
           stats,
+          messages,
+          isSuccessful,
         });
       }
     });
+  });
+  await applyHook('after.build.compile', {
+    stats,
+    isSuccessful,
+    messages,
+    taskConfig: webConfig.taskConfig,
+    esbuildCompile,
   });
   return { compiler };
 };

--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -61,15 +61,18 @@ async function webpackCompiler(options: {
       consola.warn('Compiled with warnings.\n');
       consola.warn(messages.warnings.join('\n\n'));
     }
-    await applyHook(`after.${command}.compile`, {
-      stats,
-      isSuccessful,
-      isFirstCompile,
-      urls,
-      messages,
-      taskConfig,
-      esbuildCompile,
-    });
+    // compiler.hooks.done is AsyncSeriesHook which does not support async function
+    if (command === 'start') {
+      await applyHook('after.start.compile', {
+        stats,
+        isSuccessful,
+        isFirstCompile,
+        urls,
+        messages,
+        taskConfig,
+        esbuildCompile,
+      });
+    }
   });
 
   return compiler;


### PR DESCRIPTION
由于 compiler.hooks.done 是 AsyncSeriesHook，因此不支持 async 的执行逻辑，在 start 阶段不应该等待 compiler 执行结束后才返回，而 build 阶段则需要，否则导致一些 ci 流程无法保证时序