### PR TITLE
Fix: render twice in csr

### DIFF
--- a/examples/basic-project/src/pages/about.tsx
+++ b/examples/basic-project/src/pages/about.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { Link } from 'ice';
 
 export default function About() {
-  return <><h2>About Page</h2><Link to="/">home</Link></>;
+  return (
+    <>
+      <h2>About Page</h2>
+      <Link to="/">home</Link>
+    </>
+  );
 }
 
 export function getPageConfig() {

--- a/examples/basic-project/src/pages/detail.tsx
+++ b/examples/basic-project/src/pages/detail.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { Link } from 'ice';
+
+export default function Detail() {
+  return (
+    <>
+      <h2>Detail Page</h2>
+      <Link to="/">home</Link>
+    </>
+  );
+}

--- a/examples/basic-project/src/pages/index.tsx
+++ b/examples/basic-project/src/pages/index.tsx
@@ -5,11 +5,12 @@ import styles from './index.module.css';
 
 export default function Home() {
   // const appContext = useAppContext();
-
   return (
     <>
       <h2 className={styles.title}>Home Page</h2>
       <Link to="/about">about</Link>
+      <br />
+      <Link to="/detail">detail</Link>
     </>
   );
 }

--- a/packages/runtime/src/App.tsx
+++ b/packages/runtime/src/App.tsx
@@ -4,9 +4,8 @@ import type { Navigator } from 'react-router-dom';
 import AppErrorBoundary from './AppErrorBoundary.js';
 import { AppContextProvider } from './AppContext.js';
 import type Runtime from './runtime.js';
-import { createRoutes, matchRoutes } from './routes.js';
+import { createRoutes, shouldLoadModules } from './routes.js';
 import { createTransitionManager } from './transition.js';
-import type { RouteItem, RouteModules } from './types.js';
 
 interface Props {
   runtime: Runtime;
@@ -94,27 +93,4 @@ export default function App(props: Props) {
       </AppErrorBoundary>
     </StrictMode>
   );
-}
-
-/**
- * whether or not execute `transitionManager.handleLoad` function
- */
-function shouldLoadModules(routes: RouteItem[], location: Location, routeModules: RouteModules) {
-  const matches = matchRoutes(routes, location);
-  const loadedModules = matches.filter(match => {
-    const { route: { id } } = match;
-    return routeModules[id];
-  });
-
-  if (loadedModules.length !== matches.length) {
-    // 1. the modules have not been loaded
-    return true;
-  }
-
-  return matches.some((match) => {
-    const { route: { id } } = match;
-    const { getInitialData } = routeModules[id];
-    // 2. if the page route has the getInitialData function, should load page data again
-    return !!getInitialData;
-  });
 }

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -143,7 +143,7 @@ export function matchRoutes(
 /**
  * whether or not execute `handleLoad` function in transition manager
  */
-export function shouldLoadModules(routes: RouteItem[], location: Location, routeModules: RouteModules) {
+export function checkModulesNeedToBeLoaded(routes: RouteItem[], location: Location, routeModules: RouteModules) {
   const matches = matchRoutes(routes, location);
   const loadedModules = matches.filter(match => {
     const { route: { id } } = match;

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -139,3 +139,26 @@ export function matchRoutes(
     pathnameBase,
   }));
 }
+
+/**
+ * whether or not execute `handleLoad` function in transition manager
+ */
+export function shouldLoadModules(routes: RouteItem[], location: Location, routeModules: RouteModules) {
+  const matches = matchRoutes(routes, location);
+  const loadedModules = matches.filter(match => {
+    const { route: { id } } = match;
+    return routeModules[id];
+  });
+
+  if (loadedModules.length !== matches.length) {
+    // 1. the modules have not been loaded
+    return true;
+  }
+
+  return matches.some((match) => {
+    const { route: { id } } = match;
+    const { getInitialData } = routeModules[id];
+    // 2. if the page route has the getInitialData function, should load page data again
+    return !!getInitialData;
+  });
+}


### PR DESCRIPTION
对于已被加载过的模块并且模块导出没有 `getInitialData` 方法，应该直接渲染即可，不需要 setState