### PR TITLE
chore: assets output in build

### DIFF
--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -44,6 +44,19 @@ async function webpackCompiler(options: {
     });
     const messages = formatWebpackMessages(statsData);
     const isSuccessful = !messages.errors.length && !messages.warnings.length;
+    if (isSuccessful && !process.env.DISABLE_STATS) {
+      const assetsStatsOptions = {
+        errors: false,
+        warnings: false,
+        colors: true,
+        assets: true,
+        chunks: false,
+        entrypoints: false,
+        modules: false,
+        timings: false,
+      };
+      consola.log(stats.toString(assetsStatsOptions));
+    }
     if (messages.errors.length) {
       // Only keep the first error. Others are often indicative
       // of the same problem, but confuse the reader with noise.

--- a/packages/plugin-app/src/index.ts
+++ b/packages/plugin-app/src/index.ts
@@ -49,22 +49,9 @@ const plugin: Plugin = ({ registerTask, context, onHook, registerCliOption, regi
     });
   });
 
-  onHook('after.start.compile', ({ urls, stats, messages }) => {
+  onHook('after.start.compile', ({ urls, messages }) => {
     // 包含错误时不打印 localUrl 和 assets 信息
     if (!messages.errors.length) {
-      if (!commandArgs.disableAssets) {
-        console.log(stats.toString({
-          errors: false,
-          warnings: false,
-          colors: true,
-          assets: true,
-          chunks: false,
-          entrypoints: false,
-          modules: false,
-          timings: false,
-        }));
-      }
-
       console.log();
       console.log(chalk.green(' Starting the development server at:'));
       if (process.env.CLOUDIDE_ENV) {


### PR DESCRIPTION
原日志过于简单
![image](https://user-images.githubusercontent.com/4219965/160788491-e1979207-2ee1-4b31-af7a-fa3886b1e260.png)

默认情况下 start 和 build 统一输出 assets 信息
![image](https://user-images.githubusercontent.com/4219965/160788646-b5f44185-3f68-43d7-bc66-f89584a7f0e1.png)
