### PR TITLE
Fix: fs/promises module not found in node12

### DIFF
--- a/examples/basic-project/package.json
+++ b/examples/basic-project/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ice/app": "file:../../packages/ice",
-    "@ice/plugin-auth": "^1.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "workspace:*",
+    "@ice/plugin-auth": "workspace:*",
+    "@ice/runtime": "workspace:*",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18.0.2",
     "browserslist": "^4.19.3",
     "regenerator-runtime": "^0.13.9",
-    "speed-measure-webpack-plugin": "^1.5.0"
+    "speed-measure-webpack-plugin": "^1.5.0",
+    "webpack": "^5.72.0"
   }
 }

--- a/examples/csr-project/package.json
+++ b/examples/csr-project/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ice/app": "file:../../packages/ice",
-    "@ice/plugin-auth": "^1.0.0",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "workspace:*",
+    "@ice/plugin-auth": "workspace:*",
+    "@ice/runtime": "workspace:*",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18.0.0",
     "browserslist": "^4.19.3",
     "regenerator-runtime": "^0.13.9",
-    "speed-measure-webpack-plugin": "^1.5.0"
+    "speed-measure-webpack-plugin": "^1.5.0",
+    "webpack": "^5.72.0"
   }
 }

--- a/examples/routes-generate/package.json
+++ b/examples/routes-generate/package.json
@@ -9,8 +9,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ice/app": "file:../../packages/ice",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "workspace:*",
+    "@ice/runtime": "workspace:*",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/examples/single-route/package.json
+++ b/examples/single-route/package.json
@@ -9,8 +9,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ice/app": "file:../../packages/ice",
-    "@ice/runtime": "^1.0.0",
+    "@ice/app": "workspace:*",
+    "@ice/runtime": "workspace:*",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/packages/bundles/package.json
+++ b/packages/bundles/package.json
@@ -28,6 +28,7 @@
     "css-minimizer-webpack-plugin": "3.4.1",
     "cssnano": "^5.1.7",
     "es-module-lexer": "0.10.5",
+    "eslint": "^8.14.0",
     "eslint-webpack-plugin": "3.1.1",
     "fork-ts-checker-webpack-plugin": "7.2.6",
     "fs-extra": "^10.0.0",
@@ -45,6 +46,7 @@
     "webpack": "5.72.0",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-dev-server": "4.8.1",
-    "webpack-sources": "3.2.3"
+    "webpack-sources": "3.2.3",
+    "typescript": "^4.6.4"
   }
 }

--- a/packages/ice/bin/ice-cli.mjs
+++ b/packages/ice/bin/ice-cli.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import fse from 'fs-extra';
 import { program } from 'commander';
 import detectPort from 'detect-port';
 // hijack webpack before import other modules
@@ -12,7 +12,7 @@ import checkNodeVersion from './checkNodeVersion.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 (async function () {
-  const icePackageInfo = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8'));
+  const icePackageInfo = await fse.readJSON(path.join(__dirname, '../package.json'));
   checkNodeVersion(icePackageInfo.engines.node, icePackageInfo.name);
   process.env.__ICE_VERSION__ = icePackageInfo.version;
   const cwd = process.cwd();

--- a/packages/ice/bin/ice-cli.mjs
+++ b/packages/ice/bin/ice-cli.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import fs from 'fs/promises';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { program } from 'commander';
@@ -12,7 +12,7 @@ import checkNodeVersion from './checkNodeVersion.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 (async function () {
-  const icePackageInfo = JSON.parse(await fs.readFile(path.join(__dirname, '../package.json'), 'utf-8'));
+  const icePackageInfo = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8'));
   checkNodeVersion(icePackageInfo.engines.node, icePackageInfo.name);
   process.env.__ICE_VERSION__ = icePackageInfo.version;
   const cwd = process.cwd();

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -56,6 +56,7 @@
     "@types/sass": "^1.43.1",
     "@types/temp": "^0.9.1",
     "chokidar": "^3.5.3",
+    "react": "^18.0.0",
     "webpack": "^5.72.0",
     "unplugin": "^0.3.2"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -21,6 +21,8 @@
   "devDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "@types/react": "^18.0.8",
+    "@types/react-dom": "^18.0.3",
     "regenerator-runtime": "^0.13.9"
   },
   "sideEffects": false,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -30,12 +30,14 @@
     "@ice/runtime": "^1.0.0",
     "build-scripts": "2.0.0-17",
     "esbuild": "^0.14.23",
+    "eslint": "^8.14.0",
     "eslint-webpack-plugin": "3.1.1",
     "fork-ts-checker-webpack-plugin": "7.2.6",
     "react": "^18.0.0",
     "terser": "^5.12.1",
     "unplugin": "^0.3.2",
     "webpack": "^5.72.0",
-    "webpack-dev-server": "^4.7.4"
+    "webpack-dev-server": "^4.7.4",
+    "typescript": "^4.6.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -38,7 +38,7 @@ importers:
       typescript: ^4.5.5
       vitest: ^0.9.2
     devDependencies:
-      '@applint/spec': 1.2.3_04b393dbabf8d680487f0b791513144d
+      '@applint/spec': 1.2.3_aszzhw5l7dliasd7bn4rkeyuju
       '@commitlint/cli': 16.2.3
       '@ice/bundles': link:packages/bundles
       '@types/eslint': 8.4.1
@@ -62,7 +62,7 @@ importers:
       husky: 7.0.4
       ice-npm-utils: 3.0.2
       prettier: 2.6.2
-      prettier-plugin-organize-imports: 2.3.4_prettier@2.6.2+typescript@4.6.3
+      prettier-plugin-organize-imports: 2.3.4_xp3cljvn455ahqo6v4wsh6zy64
       prettier-plugin-packagejson: 2.2.17_prettier@2.6.2
       puppeteer: 13.6.0
       react: 18.0.0
@@ -74,9 +74,9 @@ importers:
 
   examples/basic-project:
     specifiers:
-      '@ice/app': file:../../packages/ice
-      '@ice/plugin-auth': ^1.0.0
-      '@ice/runtime': ^1.0.0
+      '@ice/app': workspace:*
+      '@ice/plugin-auth': workspace:*
+      '@ice/runtime': workspace:*
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.2
       browserslist: ^4.19.3
@@ -84,6 +84,7 @@ importers:
       react-dom: ^18.0.0
       regenerator-runtime: ^0.13.9
       speed-measure-webpack-plugin: ^1.5.0
+      webpack: ^5.72.0
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/plugin-auth': link:../../packages/plugin-auth
@@ -95,13 +96,14 @@ importers:
       '@types/react-dom': 18.0.2
       browserslist: 4.20.3
       regenerator-runtime: 0.13.9
-      speed-measure-webpack-plugin: 1.5.0
+      speed-measure-webpack-plugin: 1.5.0_webpack@5.72.0
+      webpack: 5.72.0
 
   examples/csr-project:
     specifiers:
-      '@ice/app': file:../../packages/ice
-      '@ice/plugin-auth': ^1.0.0
-      '@ice/runtime': ^1.0.0
+      '@ice/app': workspace:*
+      '@ice/plugin-auth': workspace:*
+      '@ice/runtime': workspace:*
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
       browserslist: ^4.19.3
@@ -109,6 +111,7 @@ importers:
       react-dom: ^18.0.0
       regenerator-runtime: ^0.13.9
       speed-measure-webpack-plugin: ^1.5.0
+      webpack: ^5.72.0
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/plugin-auth': link:../../packages/plugin-auth
@@ -120,12 +123,13 @@ importers:
       '@types/react-dom': 18.0.2
       browserslist: 4.20.3
       regenerator-runtime: 0.13.9
-      speed-measure-webpack-plugin: 1.5.0
+      speed-measure-webpack-plugin: 1.5.0_webpack@5.72.0
+      webpack: 5.72.0
 
   examples/routes-generate:
     specifiers:
-      '@ice/app': file:../../packages/ice
-      '@ice/runtime': ^1.0.0
+      '@ice/app': workspace:*
+      '@ice/runtime': workspace:*
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
       browserslist: ^4.19.3
@@ -145,8 +149,8 @@ importers:
 
   examples/single-route:
     specifiers:
-      '@ice/app': file:../../packages/ice
-      '@ice/runtime': ^1.0.0
+      '@ice/app': workspace:*
+      '@ice/runtime': workspace:*
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
       browserslist: ^4.19.3
@@ -176,6 +180,7 @@ importers:
       css-minimizer-webpack-plugin: 3.4.1
       cssnano: ^5.1.7
       es-module-lexer: 0.10.5
+      eslint: ^8.14.0
       eslint-webpack-plugin: 3.1.1
       events: 3.3.0
       fork-ts-checker-webpack-plugin: 7.2.6
@@ -195,6 +200,7 @@ importers:
       tapable: 2.2.1
       terser: 5.12.1
       terser-webpack-plugin: 5.3.1
+      typescript: ^4.6.4
       webpack: 5.72.0
       webpack-bundle-analyzer: 4.5.0
       webpack-dev-server: 4.8.1
@@ -216,20 +222,22 @@ importers:
       css-minimizer-webpack-plugin: 3.4.1_webpack@5.72.0
       cssnano: 5.1.7_postcss@8.4.12
       es-module-lexer: 0.10.5
-      eslint-webpack-plugin: 3.1.1_eslint@8.14.0+webpack@5.72.0
-      fork-ts-checker-webpack-plugin: 7.2.6_typescript@4.6.3+webpack@5.72.0
+      eslint: 8.14.0
+      eslint-webpack-plugin: 3.1.1_7obbsy7bvh46ulalj3j352unry
+      fork-ts-checker-webpack-plugin: 7.2.6_dgip6vjrhmffcc4ihrseicj6om
       fs-extra: 10.1.0
       less-loader: 10.2.0_less@4.1.2+webpack@5.72.0
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.0_webpack@5.72.0
-      postcss-loader: 6.2.1_postcss@8.4.12+webpack@5.72.0
+      postcss-loader: 6.2.1_ophkbroklgd6jdvupnp5h6xq4i
       postcss-modules: 4.3.1_postcss@8.4.12
       postcss-nested: 5.0.6_postcss@8.4.12
       postcss-preset-env: 7.4.3_postcss@8.4.12
       sass-loader: 12.6.0_sass@1.50.0+webpack@5.72.0
       tapable: 2.2.1
       terser: 5.12.1
-      terser-webpack-plugin: 5.3.1_@swc+core@1.2.168+webpack@5.72.0
+      terser-webpack-plugin: 5.3.1_eepmasjpgx7gwhmdtn6pf7sr5m
+      typescript: 4.6.4
       webpack: 5.72.0_@swc+core@1.2.168
       webpack-bundle-analyzer: 4.5.0
       webpack-dev-server: 4.8.1_webpack@5.72.0
@@ -266,6 +274,7 @@ importers:
       mrmime: ^1.0.0
       open: ^8.4.0
       prettier: ^2.5.1
+      react: ^18.0.0
       react-router: ^6.3.0
       sass: ^1.49.9
       semver: ^7.3.5
@@ -311,7 +320,8 @@ importers:
       '@types/sass': 1.43.1
       '@types/temp': 0.9.1
       chokidar: 3.5.3
-      unplugin: 0.3.3_esbuild@0.14.38+webpack@5.72.0
+      react: 18.0.0
+      unplugin: 0.3.3_7m4vrr5pcg6juvld3psuif5zsi
       webpack: 5.72.0_esbuild@0.14.38
 
   packages/plugin-auth:
@@ -328,6 +338,8 @@ importers:
 
   packages/runtime:
     specifiers:
+      '@types/react': ^18.0.8
+      '@types/react-dom': ^18.0.3
       history: ^5.3.0
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -335,8 +347,10 @@ importers:
       regenerator-runtime: ^0.13.9
     dependencies:
       history: 5.3.0
-      react-router-dom: 6.3.0_react-dom@18.0.0+react@18.0.0
+      react-router-dom: 6.3.0_zpnidt7m3osuk7shl3s4oenomq
     devDependencies:
+      '@types/react': 18.0.8
+      '@types/react-dom': 18.0.3
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       regenerator-runtime: 0.13.9
@@ -347,10 +361,12 @@ importers:
       '@ice/runtime': ^1.0.0
       build-scripts: 2.0.0-17
       esbuild: ^0.14.23
+      eslint: ^8.14.0
       eslint-webpack-plugin: 3.1.1
       fork-ts-checker-webpack-plugin: 7.2.6
       react: ^18.0.0
       terser: ^5.12.1
+      typescript: ^4.6.4
       unplugin: ^0.3.2
       webpack: ^5.72.0
       webpack-dev-server: ^4.7.4
@@ -359,11 +375,13 @@ importers:
       '@ice/runtime': link:../runtime
       build-scripts: 2.0.0-17
       esbuild: 0.14.38
-      eslint-webpack-plugin: 3.1.1_eslint@8.14.0+webpack@5.72.0
-      fork-ts-checker-webpack-plugin: 7.2.6_typescript@4.6.3+webpack@5.72.0
+      eslint: 8.14.0
+      eslint-webpack-plugin: 3.1.1_7obbsy7bvh46ulalj3j352unry
+      fork-ts-checker-webpack-plugin: 7.2.6_dgip6vjrhmffcc4ihrseicj6om
       react: 18.0.0
       terser: 5.12.1
-      unplugin: 0.3.3_esbuild@0.14.38+webpack@5.72.0
+      typescript: 4.6.4
+      unplugin: 0.3.3_7m4vrr5pcg6juvld3psuif5zsi
       webpack: 5.72.0_esbuild@0.14.38
       webpack-dev-server: 4.8.1_webpack@5.72.0
 
@@ -389,7 +407,7 @@ importers:
     dependencies:
       '@builder/swc': 0.1.3
       '@ice/bundles': link:../bundles
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.5_71ded90fc5f197eeccab1f0382e7a4aa
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.5_ohpnsd6f6gl65tfld4byfz5evi
       '@rollup/pluginutils': 4.2.1
       browserslist: 4.20.3
       consola: 2.15.3
@@ -421,7 +439,7 @@ packages:
       conventional-changelog-conventionalcommits: 4.6.3
     dev: true
 
-  /@applint/eslint-config/1.1.7_d474cfae4223bbaa57e9e20795d97f9c:
+  /@applint/eslint-config/1.1.7_2r2m7lsceo52uv7j4idzlwl7tq:
     resolution: {integrity: sha512-cyw8zAxgao9gBscoXT8LMyD/oKv3zerg6L6Y9GMaZDt99awdeGObyIDFb7tFxrgYeM3c+TUGrwNMjl8J4qzRiw==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '>=5.0.0'
@@ -432,8 +450,8 @@ packages:
       eslint-plugin-react: '>=7.26.1'
       eslint-plugin-react-hooks: '>=4.2.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.21.0_829e74f28e9c9eb05edda582d47d45b8
-      '@typescript-eslint/parser': 5.21.0_eslint@8.14.0+typescript@4.6.3
+      '@typescript-eslint/eslint-plugin': 5.21.0_qkphj4uotsplaxw5uwbni7kfxa
+      '@typescript-eslint/parser': 5.21.0_5wsz2tb7zzudmaqxfve53vbauu
       eslint: 8.14.0
       eslint-plugin-import: 2.26.0_eslint@8.14.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.14.0
@@ -449,7 +467,7 @@ packages:
     resolution: {integrity: sha512-E9j36XUQQ61ghAzosPORABOB8GGMtZ/ZRHOBjsQ7Cr4PgU7zhNbClsoaie6wimRSZfOt9OUR/rAPR4u3rY43Hg==}
     dev: true
 
-  /@applint/spec/1.2.3_04b393dbabf8d680487f0b791513144d:
+  /@applint/spec/1.2.3_aszzhw5l7dliasd7bn4rkeyuju:
     resolution: {integrity: sha512-6Wx4FHYB71NYywVi7zu1JAkRCGP73bH1mjQIHVhTp0JWenC0bs1210ofjrjwJntuRYMc+JF22XA1YVwbiRmXbw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -457,14 +475,14 @@ packages:
       stylelint: '>=14.0.0'
     dependencies:
       '@applint/commitlint-config': 1.0.2
-      '@applint/eslint-config': 1.1.7_d474cfae4223bbaa57e9e20795d97f9c
+      '@applint/eslint-config': 1.1.7_2r2m7lsceo52uv7j4idzlwl7tq
       '@applint/prettier-config': 1.0.1
-      '@applint/stylelint-config': 1.0.2_43b4330f7521963bf235751cac3b06fb
+      '@applint/stylelint-config': 1.0.2_io2dgd3vegldx4rvouokyoyg7m
       '@babel/core': 7.17.9
-      '@babel/eslint-parser': 7.17.0_@babel+core@7.17.9+eslint@8.14.0
+      '@babel/eslint-parser': 7.17.0_emkcycn4rehlrwjob5s3c77k2i
       '@babel/preset-react': 7.16.7_@babel+core@7.17.9
-      '@typescript-eslint/eslint-plugin': 5.21.0_829e74f28e9c9eb05edda582d47d45b8
-      '@typescript-eslint/parser': 5.21.0_eslint@8.14.0+typescript@4.6.3
+      '@typescript-eslint/eslint-plugin': 5.21.0_qkphj4uotsplaxw5uwbni7kfxa
+      '@typescript-eslint/parser': 5.21.0_5wsz2tb7zzudmaqxfve53vbauu
       deepmerge: 4.2.2
       eslint: 8.14.0
       eslint-config-ali: 13.1.0_eslint@8.14.0
@@ -487,7 +505,7 @@ packages:
       - typescript
     dev: true
 
-  /@applint/stylelint-config/1.0.2_43b4330f7521963bf235751cac3b06fb:
+  /@applint/stylelint-config/1.0.2_io2dgd3vegldx4rvouokyoyg7m:
     resolution: {integrity: sha512-qJGy/91OIj2YA6mF21UC0O7Ab1TT28fUt4OgZXZ/kdrgvEHek7/2njoN1f4RRNM9Q0R/+fQYjfGc2mrN+M47Kw==}
     peerDependencies:
       postcss: '>=8.0.0'
@@ -544,7 +562,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.17.0_@babel+core@7.17.9+eslint@8.14.0:
+  /@babel/eslint-parser/7.17.0_emkcycn4rehlrwjob5s3c77k2i:
     resolution: {integrity: sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -935,7 +953,7 @@ packages:
       '@types/node': 17.0.27
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 1.0.9_237e4226c9260fe57b2f293b24795fca
+      cosmiconfig-typescript-loader: 1.0.9_en7eejwjeyh6k6zpfe5si6k7zi
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.6.3
@@ -1183,7 +1201,7 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.5_71ded90fc5f197eeccab1f0382e7a4aa:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.5_ohpnsd6f6gl65tfld4byfz5evi:
     resolution: {integrity: sha512-RbG7h6TuP6nFFYKJwbcToA1rjC1FyPg25NR2noAZ0vKI+la01KTSRPkuVPE+U88jXv7javx2JHglUcL1MHcshQ==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -1575,8 +1593,22 @@ packages:
       '@types/react': 18.0.7
     dev: true
 
+  /@types/react-dom/18.0.3:
+    resolution: {integrity: sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==}
+    dependencies:
+      '@types/react': 18.0.8
+    dev: true
+
   /@types/react/18.0.7:
     resolution: {integrity: sha512-CXSXHzTexlX9esf4ReIUJeaemKcmBEvYzxHDUk19c3BCcEGUvUjkeC3jkscPSfSaQ6SPDRNd/zMxi8oc/P1zxA==}
+    dependencies:
+      '@types/prop-types': 15.7.5
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.11
+    dev: true
+
+  /@types/react/18.0.8:
+    resolution: {integrity: sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -1648,7 +1680,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.21.0_829e74f28e9c9eb05edda582d47d45b8:
+  /@typescript-eslint/eslint-plugin/5.21.0_qkphj4uotsplaxw5uwbni7kfxa:
     resolution: {integrity: sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1659,10 +1691,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.21.0_eslint@8.14.0+typescript@4.6.3
+      '@typescript-eslint/parser': 5.21.0_5wsz2tb7zzudmaqxfve53vbauu
       '@typescript-eslint/scope-manager': 5.21.0
-      '@typescript-eslint/type-utils': 5.21.0_eslint@8.14.0+typescript@4.6.3
-      '@typescript-eslint/utils': 5.21.0_eslint@8.14.0+typescript@4.6.3
+      '@typescript-eslint/type-utils': 5.21.0_5wsz2tb7zzudmaqxfve53vbauu
+      '@typescript-eslint/utils': 5.21.0_5wsz2tb7zzudmaqxfve53vbauu
       debug: 4.3.4
       eslint: 8.14.0
       functional-red-black-tree: 1.0.1
@@ -1675,7 +1707,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.21.0_eslint@8.14.0+typescript@4.6.3:
+  /@typescript-eslint/parser/5.21.0_5wsz2tb7zzudmaqxfve53vbauu:
     resolution: {integrity: sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1703,7 +1735,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.21.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.21.0_eslint@8.14.0+typescript@4.6.3:
+  /@typescript-eslint/type-utils/5.21.0_5wsz2tb7zzudmaqxfve53vbauu:
     resolution: {integrity: sha512-MxmLZj0tkGlkcZCSE17ORaHl8Th3JQwBzyXL/uvC6sNmu128LsgjTX0NIzy+wdH2J7Pd02GN8FaoudJntFvSOw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1713,7 +1745,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.21.0_eslint@8.14.0+typescript@4.6.3
+      '@typescript-eslint/utils': 5.21.0_5wsz2tb7zzudmaqxfve53vbauu
       debug: 4.3.4
       eslint: 8.14.0
       tsutils: 3.21.0_typescript@4.6.3
@@ -1748,7 +1780,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.21.0_eslint@8.14.0+typescript@4.6.3:
+  /@typescript-eslint/utils/5.21.0_5wsz2tb7zzudmaqxfve53vbauu:
     resolution: {integrity: sha512-q/emogbND9wry7zxy7VYri+7ydawo2HDZhRZ5k6yggIvXa7PvBbAAZ4PFH/oZLem72ezC4Pr63rJvDK/sTlL8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2629,7 +2661,7 @@ packages:
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /cosmiconfig-typescript-loader/1.0.9_237e4226c9260fe57b2f293b24795fca:
+  /cosmiconfig-typescript-loader/1.0.9_en7eejwjeyh6k6zpfe5si6k7zi:
     resolution: {integrity: sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -2638,7 +2670,7 @@ packages:
     dependencies:
       '@types/node': 17.0.27
       cosmiconfig: 7.0.1
-      ts-node: 10.7.0_237e4226c9260fe57b2f293b24795fca
+      ts-node: 10.7.0_en7eejwjeyh6k6zpfe5si6k7zi
       typescript: 4.6.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -3624,7 +3656,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-webpack-plugin/3.1.1_eslint@8.14.0+webpack@5.72.0:
+  /eslint-webpack-plugin/3.1.1_7obbsy7bvh46ulalj3j352unry:
     resolution: {integrity: sha512-xSucskTN9tOkfW7so4EaiFIkulWLXwCB/15H917lR6pTv0Zot6/fetFucmENRb7J5whVSFKIvwnrnsa78SG2yg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -3992,7 +4024,7 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /fork-ts-checker-webpack-plugin/7.2.6_typescript@4.6.3+webpack@5.72.0:
+  /fork-ts-checker-webpack-plugin/7.2.6_dgip6vjrhmffcc4ihrseicj6om:
     resolution: {integrity: sha512-q5rdvy7CaqEWyK3ly/AjSMQ+e3DGkjuqP0pkTwJcg+PHLhQfTJXqkmRIeA2y0TPfX4U00Et+AxS2ObAsVcm0hQ==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -4014,7 +4046,7 @@ packages:
       schema-utils: 3.1.1
       semver: 7.3.7
       tapable: 2.2.1
-      typescript: 4.6.3
+      typescript: 4.6.4
       webpack: 5.72.0_@swc+core@1.2.168
     dev: true
 
@@ -6015,7 +6047,7 @@ packages:
       postcss: 8.4.12
     dev: true
 
-  /postcss-loader/6.2.1_postcss@8.4.12+webpack@5.72.0:
+  /postcss-loader/6.2.1_ophkbroklgd6jdvupnp5h6xq4i:
     resolution: {integrity: sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -6498,7 +6530,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-organize-imports/2.3.4_prettier@2.6.2+typescript@4.6.3:
+  /prettier-plugin-organize-imports/2.3.4_xp3cljvn455ahqo6v4wsh6zy64:
     resolution: {integrity: sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==}
     peerDependencies:
       prettier: '>=2.0'
@@ -6650,7 +6682,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react-router-dom/6.3.0_react-dom@18.0.0+react@18.0.0:
+  /react-router-dom/6.3.0_zpnidt7m3osuk7shl3s4oenomq:
     resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
     peerDependencies:
       react: '>=16.8'
@@ -7188,13 +7220,14 @@ packages:
     hasBin: true
     dev: true
 
-  /speed-measure-webpack-plugin/1.5.0:
+  /speed-measure-webpack-plugin/1.5.0_webpack@5.72.0:
     resolution: {integrity: sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
       webpack: ^1 || ^2 || ^3 || ^4 || ^5
     dependencies:
       chalk: 4.1.2
+      webpack: 5.72.0
     dev: true
 
   /split2/3.2.2:
@@ -7496,32 +7529,7 @@ packages:
       rimraf: 2.6.3
     dev: false
 
-  /terser-webpack-plugin/5.3.1_@swc+core@1.2.168+webpack@5.72.0:
-    resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@swc/core': 1.2.168
-      jest-worker: 27.5.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      source-map: 0.6.1
-      terser: 5.12.1
-      webpack: 5.72.0_@swc+core@1.2.168
-    dev: true
-
-  /terser-webpack-plugin/5.3.1_esbuild@0.14.38+webpack@5.72.0:
+  /terser-webpack-plugin/5.3.1_7m4vrr5pcg6juvld3psuif5zsi:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -7544,6 +7552,31 @@ packages:
       source-map: 0.6.1
       terser: 5.12.1
       webpack: 5.72.0_esbuild@0.14.38
+    dev: true
+
+  /terser-webpack-plugin/5.3.1_eepmasjpgx7gwhmdtn6pf7sr5m:
+    resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@swc/core': 1.2.168
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      source-map: 0.6.1
+      terser: 5.12.1
+      webpack: 5.72.0_@swc+core@1.2.168
     dev: true
 
   /terser-webpack-plugin/5.3.1_webpack@5.72.0:
@@ -7677,7 +7710,7 @@ packages:
       - supports-color
     dev: false
 
-  /ts-node/10.7.0_237e4226c9260fe57b2f293b24795fca:
+  /ts-node/10.7.0_en7eejwjeyh6k6zpfe5si6k7zi:
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
     peerDependencies:
@@ -7784,6 +7817,12 @@ packages:
     hasBin: true
     dev: true
 
+  /typescript/4.6.4:
+    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
   /unbox-primitive/1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -7816,7 +7855,7 @@ packages:
     resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
     engines: {node: '>= 0.8'}
 
-  /unplugin/0.3.3_esbuild@0.14.38+webpack@5.72.0:
+  /unplugin/0.3.3_7m4vrr5pcg6juvld3psuif5zsi:
     resolution: {integrity: sha512-WjZWpUqqcYPQ/efR00Zm2m1+J1LitwoZ4uhHV4VdZ+IpW0Nh/qnDYtVf+nLhozXdGxslMPecOshVR7NiWFl4gA==}
     peerDependencies:
       esbuild: '>=0.13'
@@ -8168,7 +8207,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.1_@swc+core@1.2.168+webpack@5.72.0
+      terser-webpack-plugin: 5.3.1_eepmasjpgx7gwhmdtn6pf7sr5m
       watchpack: 2.3.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -8208,7 +8247,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.1_esbuild@0.14.38+webpack@5.72.0
+      terser-webpack-plugin: 5.3.1_7m4vrr5pcg6juvld3psuif5zsi
       watchpack: 2.3.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
`fs/promises` 只在 node 14+ 支持

ref:
- https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_promises_api
- https://github.com/SAP-samples/hana-developer-cli-tool-example/issues/57


一些依赖版本修改说明：
由于 pnpm 发布 7.0.0 版本，导致在执行 build 的时候报错。
- 补全了丢失的 peerDependencies
- 指定 examples 中依赖的 `@ice/*` 的包是从 workspace 中依赖的。Ref: https://pnpm.io/zh/workspaces#workspace-%E5%8D%8F%E8%AE%AE-workspace
- 补全了一些丢失的 `@types/*` 的包，避免执行 build 的时候报错