### PR TITLE
Fix: csr load component module

### DIFF
--- a/packages/ice/src/plugins/web/index.ts
+++ b/packages/ice/src/plugins/web/index.ts
@@ -16,7 +16,8 @@ const webPlugin: Plugin = ({ registerTask, context, onHook }) => {
   const routeManifest = path.join(rootDir, '.ice/route-manifest.json');
   const mode = command === 'start' ? 'development' : 'production';
   const assetsManifest = path.join(rootDir, '.ice/assets-manifest.json');
-  const serverEntry = path.join(outputDir, 'server/index.mjs');
+  const serverOutputDir = path.join(outputDir, 'server');
+  const serverEntry = path.join(serverOutputDir, 'index.mjs');
   let serverCompiler = async () => '';
 
   onHook(`before.${command as 'start' | 'build'}.run`, async ({ esbuildCompile }) => {
@@ -35,10 +36,13 @@ const webPlugin: Plugin = ({ registerTask, context, onHook }) => {
 
     serverCompiler = async () => {
       await esbuildCompile({
-        entryPoints: [path.join(rootDir, '.ice/entry.server')],
-        outfile: serverEntry,
+        entryPoints: {
+          index: path.join(rootDir, '.ice/entry.server'),
+        },
+        outdir: serverOutputDir,
         // platform: 'node',
         format: 'esm',
+        splitting: true,
         outExtension: { '.js': '.mjs' },
         define: runtimeDefineVars,
         plugins: [

--- a/packages/ice/src/service/compile.ts
+++ b/packages/ice/src/service/compile.ts
@@ -46,7 +46,7 @@ export function createEsbuildCompiler(options: Options) {
 
     const buildResult = await esbuild.build({
       bundle: true,
-      target: 'node12.19.0',
+      target: 'node12.20.0',
       ...buildOptions,
       define,
       inject: [path.resolve(__dirname, '../polyfills/react.js')],

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -81,12 +81,16 @@ export function getRoutesConfig(matches: RouteMatch[], routesData: RoutesData): 
   matches.forEach(async (match) => {
     const { id } = match.route;
     const routeModule = routeModules[id];
-    const { getConfig } = routeModule;
-    const data = routesData[id];
 
-    if (getConfig) {
-      const value = getConfig({ data });
-      routesConfig[id] = value;
+    if (typeof routeModule === 'object') {
+      const { getConfig } = routeModule;
+      const data = routesData[id];
+      if (getConfig) {
+        const value = getConfig({ data });
+        routesConfig[id] = value;
+      }
+    } else {
+      routesConfig[id] = {};
     }
   });
 

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -130,10 +130,11 @@ async function doRender(serverContext: ServerContext, options: RenderOptions): P
 
   if (documentOnly) {
     return renderDocument(matches, options);
-  } else {
-    // TODO: 调用 renderHTML 的时候 getConfig 失效了
-    await loadRouteModules(matches.map(({ route: { id, load } }) => ({ id, load })));
   }
+
+  // FIXME: 原来是在 renderDocument 之前执行这段逻辑。
+  // 现在为了避免 CSR 时把页面组件都加载进来导致资源（比如 css）加载报错，带来的问题是调用 renderHTML 的时候 getConfig 失效了
+  await loadRouteModules(matches.map(({ route: { id, load } }) => ({ id, load })));
 
   try {
     return await renderServerEntry(serverContext, options, matches, location);

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -128,10 +128,11 @@ async function doRender(serverContext: ServerContext, options: RenderOptions): P
     return render404();
   }
 
-  await loadRouteModules(matches.map(({ route: { id, load } }) => ({ id, load })));
-
   if (documentOnly) {
     return renderDocument(matches, options);
+  } else {
+    // TODO: 调用 renderHTML 的时候 getConfig 失效了
+    await loadRouteModules(matches.map(({ route: { id, load } }) => ({ id, load })));
   }
 
   try {


### PR DESCRIPTION
现在为了避免 CSR 时把页面组件都加载进来导致资源（比如 css）加载报错，带来的问题是调用 renderHTML 的时候 getConfig 失效了，后面需要讨论。

如果用 esbuild 打包成一个 server bundle 时，会有以下产物：

![image](https://user-images.githubusercontent.com/44047106/166877713-58ef7b1c-ed27-4c66-83ef-cccd4068fbb3.png)
![image](https://user-images.githubusercontent.com/44047106/166877727-6d1bb8b2-0a80-4957-9de2-1df473cb4204.png)
![image](https://user-images.githubusercontent.com/44047106/166877743-bec7a02c-0a5c-411f-80a8-881fc297f225.png)
这时候，加载 server bundle 时，就会把所有的 页面组件都加载进来了。

因此需要开启分包 （splitting: true）