### PR TITLE
Fix: app.addProvider not be added

### DIFF
--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -8,6 +8,12 @@
   "bin": {
     "ice": "./bin/ice-cli.mjs"
   },
+  "files": [
+    "bin",
+    "esm",
+    "template",
+    "!esm/**/*.map"
+  ],
   "engines": {
     "node": ">=12.22.0",
     "npm": ">=3.0.0"

--- a/packages/ice/src/plugins/web/ssr/serverRender.ts
+++ b/packages/ice/src/plugins/web/ssr/serverRender.ts
@@ -33,7 +33,7 @@ export function setupRenderServer(options: Options) {
       serverEntry = await import(entry);
     } catch (err) {
       // make error clearly, notice typeof err === 'string'
-      res.end(`import ${entry} error: ${err}`);
+      return res.end(`import ${entry} error: ${err}`);
     }
 
     const serverContext: ServerContext = {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,7 +11,8 @@
     "./server": "./esm/index.server.js"
   },
   "files": [
-    "esm"
+    "esm",
+    "!esm/**/*.map"
   ],
   "author": "ICE",
   "license": "MIT",

--- a/packages/runtime/src/runtime.tsx
+++ b/packages/runtime/src/runtime.tsx
@@ -30,7 +30,7 @@ class Runtime {
   private render: Renderer;
 
   public constructor(appContext: AppContext) {
-    this.AppProvider = [];
+    this.AppProvider = [appContext.appConfig.app.addProvider];
     this.appContext = appContext;
     this.render = (container, element) => {
       const root = ReactDOM.createRoot(container);

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -9,7 +9,7 @@ type VoidFunction = () => void;
 type AppLifecycle = 'onShow' | 'onHide' | 'onPageNotFound' | 'onShareAppMessage' | 'onUnhandledRejection' | 'onLaunch' | 'onError' | 'onTabItemClick';
 type App = Partial<{
   strict?: boolean;
-  addProvider?: ({ children }: { children: ReactNode }) => ReactNode;
+  addProvider?: ComponentWithChildren;
 } & Record<AppLifecycle, VoidFunction>>;
 
 export type AppData = any;


### PR DESCRIPTION
Fix: app.addProvider 设置了但未生效

额外修复两个问题：
- 调用了 `res.end()` 后，后面的逻辑仍然运行了
- 避免安装 npm 包时下载没必要的文件