### PR TITLE
feat: add modifyRenderData api

### DIFF
--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -58,6 +58,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
     },
     addRenderFile: generator.addRenderFile,
     addRenderTemplate: generator.addTemplateFiles,
+    modifyRenderData: generator.modifyRenderData,
   };
 
   const ctx = new Context<any, ExtendsPluginAPI>({


### PR DESCRIPTION
### 背景
def 发布时，由于发布的 html 地址是 https://xxx.taobao.com/app/ice-test/ice-simple-3/blog.html，渲染时路由会匹配不上，因此需要在 def plugin 中修改路由的 path 值，增加类似 `/app/ice-test/ice-simple-3` 路由前缀。

### 方案

需要新增 modifyRenderData 的 API，支持修改 routeManifest 和 route 值