### PR TITLE
Fix: define config types is missing

### DIFF
--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -25,8 +25,9 @@
   "bugs": "https://github.com/ice-lab/ice-next/issues",
   "homepage": "https://next.ice.work",
   "dependencies": {
-    "@ice/runtime": "^1.0.0",
     "@ice/bundles": "^0.1.0",
+    "@ice/types": "^1.0.0",
+    "@ice/runtime": "^1.0.0",
     "@ice/route-manifest": "^1.0.0",
     "@ice/webpack-config": "^1.0.0",
     "address": "^1.1.2",
@@ -61,7 +62,6 @@
   },
   "devDependencies": {
     "express": "^4.18.0",
-    "@ice/types": "^1.0.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/ejs": "^3.1.0",
     "@types/less": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,7 @@ importers:
       '@ice/bundles': link:../bundles
       '@ice/route-manifest': link:../route-manifest
       '@ice/runtime': link:../runtime
+      '@ice/types': link:../types
       '@ice/webpack-config': link:../webpack-config
       address: 1.1.2
       body-parser: 1.20.0
@@ -330,7 +331,6 @@ importers:
       trusted-cert: 1.1.3
       webpack-dev-server: 4.8.1_webpack@5.72.0
     devDependencies:
-      '@ice/types': link:../types
       '@types/cross-spawn': 6.0.2
       '@types/ejs': 3.1.0
       '@types/less': 3.0.3


### PR DESCRIPTION
安装 `@ice/app` 这个包时候，`@ice/types` 这个包不会被安装，因为它是放在 devDependencies

![image](https://user-images.githubusercontent.com/44047106/167242046-5444023b-eed0-4338-bcd9-173baf33ae44.png)
