### PR TITLE
fix: webpack/hot alias

### DIFF
--- a/packages/ice/src/commands/build.ts
+++ b/packages/ice/src/commands/build.ts
@@ -8,7 +8,7 @@ import type { ServerCompiler } from '@ice/types/esm/plugin.js';
 import webpack from '@ice/bundles/compiled/webpack/index.js';
 import webpackCompiler from '../service/webpackCompiler.js';
 import formatWebpackMessages from '../utils/formatWebpackMessages.js';
-import { SERVER_ENTRY, SERVER_OUTPUT } from '../constant.js';
+import { SERVER_ENTRY, SERVER_OUTPUT, SERVER_OUTPUT_DIR } from '../constant.js';
 import generateHTML from '../utils/generateHTML.js';
 import emptyDir from '../utils/emptyDir.js';
 
@@ -57,8 +57,9 @@ const build = async (context: Context<Config>, taskConfigs: TaskConfig<Config>[]
         // compile server bundle
         const outfile = path.join(outputDir, SERVER_OUTPUT);
         await serverCompiler({
-          entryPoints: [path.join(rootDir, SERVER_ENTRY)],
-          outfile,
+          entryPoints: { index: path.join(rootDir, SERVER_ENTRY) },
+          outdir: path.join(outputDir, SERVER_OUTPUT_DIR),
+          splitting: true,
         });
         // generate html
         const { ssg = true, ssr = true } = userConfig;

--- a/packages/ice/src/constant.ts
+++ b/packages/ice/src/constant.ts
@@ -1,4 +1,5 @@
 export const ROUTER_MANIFEST = '.ice/route-manifest.json';
 export const ASSETS_MANIFEST = '.ice/assets-manifest.json';
 export const SERVER_ENTRY = '.ice/entry.server';
-export const SERVER_OUTPUT = 'server/index.mjs';
+export const SERVER_OUTPUT_DIR = 'server';
+export const SERVER_OUTPUT = `${SERVER_OUTPUT_DIR}/index.mjs`;

--- a/packages/ice/src/middlewares/ssr.ts
+++ b/packages/ice/src/middlewares/ssr.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import type { ServerContext } from '@ice/runtime';
 import type { ServerCompiler } from '@ice/types/esm/plugin.js';
 import type { ExpressRequestHandler } from 'webpack-dev-server';
-import { SERVER_ENTRY, SERVER_OUTPUT } from '../constant.js';
+import { SERVER_ENTRY, SERVER_OUTPUT, SERVER_OUTPUT_DIR } from '../constant.js';
 
 interface Options {
   rootDir: string;
@@ -21,8 +21,9 @@ export default function createSSRMiddleware(options: Options) {
   const ssrCompiler = async () => {
     const serverEntry = path.join(outputDir, SERVER_OUTPUT);
     await serverCompiler({
-      entryPoints: [path.join(rootDir, SERVER_ENTRY)],
-      outfile: serverEntry,
+      entryPoints: { index: path.join(rootDir, SERVER_ENTRY) },
+      outdir: path.join(outputDir, SERVER_OUTPUT_DIR),
+      splitting: true,
     });
     // timestamp for disable import cache
     return `${serverEntry}?version=${new Date().getTime()}`;

--- a/packages/ice/src/service/serverCompiler.ts
+++ b/packages/ice/src/service/serverCompiler.ts
@@ -64,6 +64,7 @@ export function createServerCompiler(options: Options) {
       target: 'node12.20.0',
       ...buildOptions,
       define,
+      outExtension: { '.js': '.mjs' },
       inject: [path.resolve(__dirname, '../polyfills/react.js')],
       plugins: [
         emptyCSSPlugin(),

--- a/packages/ice/src/tasks/web/index.ts
+++ b/packages/ice/src/tasks/web/index.ts
@@ -11,6 +11,8 @@ const getWebTask = ({ rootDir, command }): Config => {
     alias: {
       ice: path.join(rootDir, '.ice', 'index.ts'),
       '@': path.join(rootDir, 'src'),
+      // set alias for webpack/hot while webpack has been prepacked
+      'webpack/hot': '@ice/bundles/compiled/webpack/hot',
     },
   };
 };

--- a/packages/types/src/plugin.ts
+++ b/packages/types/src/plugin.ts
@@ -9,7 +9,7 @@ import type { ExportData, AddRenderFile, AddTemplateFiles } from './generator.js
 
 type AddExport = (exportData: ExportData) => void;
 type EventName = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
-export type ServerCompiler = (buildOptions: Pick<BuildOptions, 'format' | 'entryPoints' | 'outfile' | 'bundle'>) => Promise<BuildResult>;
+export type ServerCompiler = (buildOptions: Pick<BuildOptions, 'format' | 'entryPoints' | 'outfile' | 'bundle' | 'outdir' | 'splitting'>) => Promise<BuildResult>;
 export type WatchEvent = [
   pattern: RegExp | string,
   event: (eventName: EventName, filePath: string) => void,

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -46,8 +46,11 @@ function getEntry(rootDir: string) {
     entryFile = path.join(rootDir, '.ice/entry.client.ts');
   }
 
+  // const dataLoaderFile = path.join(rootDir, '.ice/data-loader.ts');
   return {
     main: [entryFile],
+    // FIXME: https://github.com/ice-lab/ice-next/issues/217, https://github.com/ice-lab/ice-next/issues/199
+    // loader: [dataLoaderFile],
   };
 }
 

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -45,10 +45,9 @@ function getEntry(rootDir: string) {
     // use generated file in template directory
     entryFile = path.join(rootDir, '.ice/entry.client.ts');
   }
-  const dataLoaderFile = path.join(rootDir, '.ice/data-loader.ts');
+
   return {
     main: [entryFile],
-    loader: [dataLoaderFile],
   };
 }
 


### PR DESCRIPTION
一些变更点说明：
- 暂时去掉 loader entry，避免打包出重复的内容导致加载时间过长。后面需等待 https://github.com/ice-lab/ice-next/issues/217 解决
- 打包 serverEntry 暂时需要 `splitting: true` 原因详见：https://github.com/ice-lab/ice-next/pull/188 ，需等待 https://github.com/ice-lab/ice-next/issues/199 解决