### PR TITLE
fix: improve compile experience

### DIFF
--- a/packages/ice/src/middlewares/ssr.ts
+++ b/packages/ice/src/middlewares/ssr.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import consola from 'consola';
 import type { ServerContext } from '@ice/runtime';
 import type { ServerCompiler } from '@ice/types/esm/plugin.js';
 import type { ExpressRequestHandler } from 'webpack-dev-server';
@@ -28,15 +29,19 @@ export default function createSSRMiddleware(options: Options) {
     // timestamp for disable import cache
     return `${serverEntry}?version=${new Date().getTime()}`;
   };
-
+  let entry: string;
   const middleware: ExpressRequestHandler = async (req, res) => {
-    const entry = await ssrCompiler();
     let serverModule;
+    try {
+      entry = await ssrCompiler();
+    } catch (err) {
+      consola.error(`fail to compile in ssr middleware: ${err}`);
+    }
     try {
       serverModule = await import(entry);
     } catch (err) {
       // make error clearly, notice typeof err === 'string'
-      res.end(`import ${entry} error: ${err}`);
+      consola.error(`import ${entry} error: ${err}`);
       return;
     }
     const requestContext: ServerContext = {

--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -76,7 +76,7 @@ async function webpackCompiler(options: {
       consola.warn(messages.warnings.join('\n\n'));
     }
     if (command === 'start') {
-      if (isSuccessful) {
+      if (isSuccessful && isFirstCompile) {
         let logoutMessage = '\n';
         logoutMessage += chalk.green(' Starting the development server at:');
         if (process.env.CLOUDIDE_ENV) {

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -214,6 +214,8 @@ const getWebpackConfig: GetWebpackConfig = ({ rootDir, config, webpack }) => {
       ...webpackPlugins,
       dev && new ReactRefreshWebpackPlugin({
         exclude: [/node_modules/, /bundles\/compiled/],
+        // use webpack-dev-server overlay instead
+        overlay: false,
       }),
       new webpack.DefinePlugin({
         ...defineVars,

--- a/packages/webpack-config/src/unPlugins/compilation.ts
+++ b/packages/webpack-config/src/unPlugins/compilation.ts
@@ -1,6 +1,5 @@
 import { createRequire } from 'module';
 import type { ReactConfig } from '@builder/swc';
-import consola from 'consola';
 import { transform, type Config as SwcConfig } from '@builder/swc';
 import type { UnpluginOptions } from 'unplugin';
 import lodash from '@ice/bundles/compiled/lodash/index.js';

--- a/packages/webpack-config/src/unPlugins/compilation.ts
+++ b/packages/webpack-config/src/unPlugins/compilation.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'module';
 import type { ReactConfig } from '@builder/swc';
+import consola from 'consola';
 import { transform, type Config as SwcConfig } from '@builder/swc';
 import type { UnpluginOptions } from 'unplugin';
 import lodash from '@ice/bundles/compiled/lodash/index.js';
@@ -50,10 +51,13 @@ const compilationPlugin = (options: Options): UnpluginOptions => {
               !Object.prototype.hasOwnProperty.call(programmaticOptions.jsc.transform.react, 'development')) {
         programmaticOptions.jsc.transform.react.development = mode === 'development';
       }
-      const output = await transform(source, programmaticOptions);
-      const { code, map } = output;
-
-      return { code, map };
+      try {
+        const output = await transform(source, programmaticOptions);
+        const { code, map } = output;
+        return { code, map };
+      } catch (e) {
+        // catch error for Unhandled promise rejection
+      }
     },
   };
 };


### PR DESCRIPTION
- [x] use webpack-dev-server overlay instead of fast-resfresh to reduce ws connection #225
- [x] catch compile error for Unhandled promise rejection
- [x] do not send error message as response when ssr failed
- [x] fix open browser after every compile