### PR TITLE
fix: compat rax and warn once

### DIFF
--- a/packages/plugin-rax-compat/src/index.ts
+++ b/packages/plugin-rax-compat/src/index.ts
@@ -28,13 +28,17 @@ const ruleSetStylesheet = {
   ],
 };
 
+let warnOnce = false;
+
 function getPlugin(options: CompatRaxOptions): Plugin {
   return ({ onGetConfig }) => {
     onGetConfig((config) => {
       Object.assign(config.alias, alias);
       if (options.inlineStyle) {
-        consola.warn('[WARN] Enabling inline style is not recommended.');
-        consola.warn('       It is recommended to use CSS modules (as default). Only allow old projects to migrate and use.');
+        if (!warnOnce) {
+          consola.warn('Enabling inline style is not recommended.\n       It is recommended to use CSS modules (as default). Only allow old projects to migrate and use.');
+          warnOnce = true;
+        }
         config.configureWebpack ??= [];
         config.configureWebpack.unshift((config) => {
           const { rules } = config.module || {};

--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -54,8 +54,7 @@ export function createElement<P extends {
   props?: Attributes & P | null,
   ...children: ReactNode[]): ReactElement {
   const rest = Object.assign({}, props);
-  const { children: propsChildren, onAppear, onDisappear } = rest;
-  delete rest.children;
+  const { onAppear, onDisappear } = rest;
   delete rest.onAppear;
   delete rest.onDisappear;
 
@@ -66,8 +65,8 @@ export function createElement<P extends {
   }
 
   // Create backend element.
-  const args = [type, rest, propsChildren];
-  let element: any = _createElement.apply(null, args.concat(children));
+  const args = [type, rest];
+  let element: any = _createElement.apply(null, args.concat(children as any));
 
   // Polyfill for appear and disappear event.
   if (isFunction(onAppear) || isFunction(onDisappear)) {
@@ -89,7 +88,7 @@ const isDimensionalProp = cached((prop: string) => !NON_DIMENSIONAL_REG.test(pro
 function compatStyle<S = object>(style?: S): S | void {
   if (isObject(style)) {
     // Do not modify the original style object, copy results to another plain object.
-    const result = Object.create(null);
+    const result = Object.create(Object.prototype);
     for (let key in style) {
       const value = style[key];
       if (isNumber(value) && isDimensionalProp(key)) {

--- a/packages/rax-compat/src/hooks.ts
+++ b/packages/rax-compat/src/hooks.ts
@@ -1,23 +1,23 @@
 import type {
   Context,
   DependencyList,
-  EffectCallback,
-  ReducerWithoutAction,
-  Ref,
   DispatchWithoutAction,
+  EffectCallback,
   MutableRefObject,
   ReducerStateWithoutAction,
+  ReducerWithoutAction,
+  Ref,
 } from 'react';
 import {
-  useState as _useState,
+  useCallback as _useCallback,
   useContext as _useContext,
   useEffect as _useEffect,
-  useLayoutEffect as _useLayoutEffect,
   useImperativeHandle as _useImperativeHandle,
+  useLayoutEffect as _useLayoutEffect,
+  useMemo as _useMemo,
   useReducer as _useReducer,
   useRef as _useRef,
-  useCallback as _useCallback,
-  useMemo as _useMemo,
+  useState as _useState,
 } from 'react';
 
 /**
@@ -27,7 +27,15 @@ import {
  * @returns [ value, dispatch ]
  */
 export function useState<S>(initialState: S | (() => S)): ReturnType<typeof _useState> {
-  return _useState(initialState);
+  const stateHook = _useState(initialState);
+  // @NOTE: Rax will not re-render if set a same value.
+  function updateState(newState: S) {
+    // Filter shallow-equal value set.
+    if (newState !== stateHook[0]) {
+      stateHook[1](newState);
+    }
+  }
+  return [stateHook[0], updateState];
 }
 
 /**


### PR DESCRIPTION
1. rax-compat 修复 createElement 的 children 渲染两次的问题
2. rax-compat 修复 style 对象的 prototype 为 null 的问题
3. 限制 plugin-rax-compat 的 inlineStyle WARN 告警只提示一次
4. rax-compat 兼容 rax 的 setState 同值不重新渲染的逻辑