### PR TITLE
chore: set app.strict default value to false

### DIFF
--- a/packages/runtime/src/appConfig.ts
+++ b/packages/runtime/src/appConfig.ts
@@ -2,7 +2,7 @@ import type { AppConfig, AppExport } from './types.js';
 
 const defaultAppConfig: AppConfig = {
   app: {
-    strict: true,
+    strict: false,
     rootId: 'ice-container',
   },
   router: {


### PR DESCRIPTION
### Strict Mode（严格模式）

Strict Mode 是用于标记应用中潜在的代码问题。比如：

1. 识别出过时的生命周期、API（ref、context）、方法
2. 检测副作用（数据请求、数据订阅、修改 DOM 等），开启严格模式后会在 dev 阶段下会调用 effect 两次
	- 为什么要检查副作用？concurrent 模式下可能会多次调用 render 阶段的生命周期方法后，才到 commit 阶段。调用 effect 两次是为了在 dev 阶段能帮助开发者发现内存泄露、无效应用状态等问题
	- 如果尽量少写副作用？事件回调；getData；react-query；

### ICE 3 需要默认开启 Strict Mode？

建议默认不开启。原因有：
- 大部分开发者不知道为什么 effect 回调函数会调用两次，代码中也没有显式声明是启用 strict mode，减少认知成本
-Strict Mode 属于高级特性
- 一般上用到的流行的组件库，不会用过期的 API 或生命周期。并且我们文档有推荐数据请求的正确姿势

但文档上标明 推荐开启。

参考文档：

- https://react.docschina.org/docs/strict-mode.html
- https://segmentfault.com/a/1190000042059978
- https://segmentfault.com/a/1190000041942007