### PR TITLE
fix: can not get the NODE_ENV value in plugin

### DIFF
--- a/packages/ice/bin/ice-cli.mjs
+++ b/packages/ice/bin/ice-cli.mjs
@@ -30,6 +30,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
     .option('--config <config>', 'use custom config')
     .option('--rootDir <rootDir>', 'project root directory', cwd)
     .action(async ({ rootDir, ...commandArgs }) => {
+      process.env.NODE_ENV = 'production';
       const service = await createService({ rootDir, command: 'build', commandArgs });
       service.run();
     });
@@ -42,13 +43,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
     .option('--config <config>', 'custom config path')
     .option('-h, --host <host>', 'dev server host', '0.0.0.0')
     .option('-p, --port <port>', 'dev server port', 3000)
-    .option('--no-open', 'don\'t open browser on startup')
-    .option('--no-mock', 'don\'t start mock service')
+    .option('--no-open', "don't open browser on startup")
+    .option('--no-mock', "don't start mock service")
     .option('--rootDir <rootDir>', 'project root directory', cwd)
     .option('--analyzer', 'visualize size of output files', false)
     .option('--https [https]', 'enable https', false)
     .option('--force', 'force remove cache directory', false)
     .action(async ({ rootDir, ...commandArgs }) => {
+      process.env.NODE_ENV = 'development';
       commandArgs.port = await detectPort(commandArgs.port);
       const service = await createService({ rootDir, command: 'start', commandArgs });
       service.run();
@@ -62,6 +64,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
     .option('--config <config>', 'use custom config')
     .option('--rootDir <rootDir>', 'project root directory', cwd)
     .action(async ({ rootDir, ...commandArgs }) => {
+      process.env.NODE_ENV = 'test';
       await createService({ rootDir, command: 'test', commandArgs });
     });
 

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -35,7 +35,7 @@ interface CreateServiceOptions {
 }
 
 async function createService({ rootDir, command, commandArgs }: CreateServiceOptions) {
-  // init process.env.NODE_ENV for plugins
+  // Init process.env.NODE_ENV for plugins.
   injectNodeEnv(command);
 
   const buildSpinner = createSpinner('loading config...');

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -15,7 +15,7 @@ import build from './commands/build.js';
 import mergeTaskConfig from './utils/mergeTaskConfig.js';
 import getWatchEvents from './getWatchEvents.js';
 import { compileAppConfig } from './analyzeRuntime.js';
-import { injectEnv, updateRuntimeEnv, getCoreEnvKeys } from './utils/runtimeEnv.js';
+import { setEnv, updateRuntimeEnv, getCoreEnvKeys } from './utils/runtimeEnv.js';
 import getRuntimeModules from './utils/getRuntimeModules.js';
 import { generateRoutesInfo } from './routes.js';
 import getWebTask from './tasks/web/index.js';
@@ -107,7 +107,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
   const { userConfig } = ctx;
   const { routes: routesConfig, server } = userConfig;
 
-  await injectEnv(rootDir, commandArgs);
+  await setEnv(rootDir, commandArgs);
   const coreEnvKeys = getCoreEnvKeys();
 
   const routesInfo = await generateRoutesInfo(rootDir, routesConfig);

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -15,7 +15,7 @@ import build from './commands/build.js';
 import mergeTaskConfig from './utils/mergeTaskConfig.js';
 import getWatchEvents from './getWatchEvents.js';
 import { compileAppConfig } from './analyzeRuntime.js';
-import { initProcessEnv, updateRuntimeEnv, getCoreEnvKeys, initNodeEnv } from './utils/runtimeEnv.js';
+import { injectEnv, updateRuntimeEnv, getCoreEnvKeys, injectNodeEnv } from './utils/runtimeEnv.js';
 import getRuntimeModules from './utils/getRuntimeModules.js';
 import { generateRoutesInfo } from './routes.js';
 import getWebTask from './tasks/web/index.js';
@@ -36,7 +36,7 @@ interface CreateServiceOptions {
 
 async function createService({ rootDir, command, commandArgs }: CreateServiceOptions) {
   // init process.env.NODE_ENV for plugins
-  initNodeEnv(command);
+  injectNodeEnv(command);
 
   const buildSpinner = createSpinner('loading config...');
   const templateDir = path.join(__dirname, '../templates/');
@@ -110,8 +110,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
   const { userConfig } = ctx;
   const { routes: routesConfig, server } = userConfig;
 
-  // load dotenv, set to process.env
-  await initProcessEnv(rootDir, commandArgs);
+  await injectEnv(rootDir, commandArgs);
   const coreEnvKeys = getCoreEnvKeys();
 
   const routesInfo = await generateRoutesInfo(rootDir, routesConfig);

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -15,7 +15,7 @@ import build from './commands/build.js';
 import mergeTaskConfig from './utils/mergeTaskConfig.js';
 import getWatchEvents from './getWatchEvents.js';
 import { compileAppConfig } from './analyzeRuntime.js';
-import { injectEnv, updateRuntimeEnv, getCoreEnvKeys, injectNodeEnv } from './utils/runtimeEnv.js';
+import { injectEnv, updateRuntimeEnv, getCoreEnvKeys } from './utils/runtimeEnv.js';
 import getRuntimeModules from './utils/getRuntimeModules.js';
 import { generateRoutesInfo } from './routes.js';
 import getWebTask from './tasks/web/index.js';
@@ -35,9 +35,6 @@ interface CreateServiceOptions {
 }
 
 async function createService({ rootDir, command, commandArgs }: CreateServiceOptions) {
-  // Init process.env.NODE_ENV for plugins.
-  injectNodeEnv(command);
-
   const buildSpinner = createSpinner('loading config...');
   const templateDir = path.join(__dirname, '../templates/');
   const configFile = 'ice.config.(mts|mjs|ts|js|cjs|json)';

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -15,7 +15,7 @@ import build from './commands/build.js';
 import mergeTaskConfig from './utils/mergeTaskConfig.js';
 import getWatchEvents from './getWatchEvents.js';
 import { compileAppConfig } from './analyzeRuntime.js';
-import { initProcessEnv, updateRuntimeEnv, getCoreEnvKeys } from './utils/runtimeEnv.js';
+import { initProcessEnv, updateRuntimeEnv, getCoreEnvKeys, initNodeEnv } from './utils/runtimeEnv.js';
 import getRuntimeModules from './utils/getRuntimeModules.js';
 import { generateRoutesInfo } from './routes.js';
 import getWebTask from './tasks/web/index.js';
@@ -35,6 +35,9 @@ interface CreateServiceOptions {
 }
 
 async function createService({ rootDir, command, commandArgs }: CreateServiceOptions) {
+  // init process.env.NODE_ENV for plugins
+  initNodeEnv(command);
+
   const buildSpinner = createSpinner('loading config...');
   const templateDir = path.join(__dirname, '../templates/');
   const configFile = 'ice.config.(mts|mjs|ts|js|cjs|json)';
@@ -108,7 +111,7 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
   const { routes: routesConfig, server } = userConfig;
 
   // load dotenv, set to process.env
-  await initProcessEnv(rootDir, command, commandArgs);
+  await initProcessEnv(rootDir, commandArgs);
   const coreEnvKeys = getCoreEnvKeys();
 
   const routesInfo = await generateRoutesInfo(rootDir, routesConfig);

--- a/packages/ice/src/utils/runtimeEnv.ts
+++ b/packages/ice/src/utils/runtimeEnv.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 import { expand as dotenvExpand } from 'dotenv-expand';
-import type { CommandArgs, CommandName } from 'build-scripts';
+import type { CommandArgs } from 'build-scripts';
 import type { AppConfig } from '@ice/types';
 
 export interface Envs {
@@ -10,17 +10,6 @@ export interface Envs {
 }
 interface EnvOptions {
   disableRouter: boolean;
-}
-
-export async function injectNodeEnv(command: CommandName) {
-  if (process.env.TEST || command === 'test') {
-    process.env.NODE_ENV = 'test';
-  } else if (command === 'start') {
-    process.env.NODE_ENV = 'development';
-  } else {
-    // build
-    process.env.NODE_ENV = 'production';
-  }
 }
 
 /**

--- a/packages/ice/src/utils/runtimeEnv.ts
+++ b/packages/ice/src/utils/runtimeEnv.ts
@@ -12,7 +12,7 @@ interface EnvOptions {
   disableRouter: boolean;
 }
 
-export async function initNodeEnv(command: CommandName) {
+export async function injectNodeEnv(command: CommandName) {
   if (process.env.TEST || command === 'test') {
     process.env.NODE_ENV = 'test';
   } else if (command === 'start') {
@@ -23,7 +23,10 @@ export async function initNodeEnv(command: CommandName) {
   }
 }
 
-export async function initProcessEnv(
+/**
+ * Inject the env params in .env file and built-in env params to process.env.
+ */
+export async function injectEnv(
   rootDir: string,
   commandArgs: CommandArgs,
 ): Promise<void> {

--- a/packages/ice/src/utils/runtimeEnv.ts
+++ b/packages/ice/src/utils/runtimeEnv.ts
@@ -12,9 +12,19 @@ interface EnvOptions {
   disableRouter: boolean;
 }
 
+export async function initNodeEnv(command: CommandName) {
+  if (process.env.TEST || command === 'test') {
+    process.env.NODE_ENV = 'test';
+  } else if (command === 'start') {
+    process.env.NODE_ENV = 'development';
+  } else {
+    // build
+    process.env.NODE_ENV = 'production';
+  }
+}
+
 export async function initProcessEnv(
   rootDir: string,
-  command: CommandName,
   commandArgs: CommandArgs,
 ): Promise<void> {
   const { mode } = commandArgs;
@@ -40,15 +50,6 @@ export async function initProcessEnv(
 
   process.env.ICE_CORE_MODE = mode;
   process.env.ICE_CORE_DEV_PORT = commandArgs.port;
-
-  if (process.env.TEST || command === 'test') {
-    process.env.NODE_ENV = 'test';
-  } else if (command === 'start') {
-    process.env.NODE_ENV = 'development';
-  } else {
-    // build
-    process.env.NODE_ENV = 'production';
-  }
 
   // set runtime initial env
   process.env.ICE_CORE_ROUTER = 'true';

--- a/packages/ice/src/utils/runtimeEnv.ts
+++ b/packages/ice/src/utils/runtimeEnv.ts
@@ -13,9 +13,9 @@ interface EnvOptions {
 }
 
 /**
- * Inject the env params in .env file and built-in env params to process.env.
+ * Set env params in .env file and built-in env params to process.env.
  */
-export async function injectEnv(
+export async function setEnv(
   rootDir: string,
   commandArgs: CommandArgs,
 ): Promise<void> {


### PR DESCRIPTION
在插件 (faas 插件) 加载的时候，拿到 process.env.NODE_ENV 的值是 undefined