### PR TITLE
feat: support pass server build options

### DIFF
--- a/packages/ice/src/service/serverCompiler.ts
+++ b/packages/ice/src/service/serverCompiler.ts
@@ -32,6 +32,7 @@ export function createServerCompiler(options: Options) {
   const { task, rootDir, command, server } = options;
 
   const alias = (task.config?.alias || {}) as Record<string, string | false>;
+  const inject = task.config?.server?.buildOptions?.inject || [];
   const assetsManifest = path.join(rootDir, ASSETS_MANIFEST);
   const define = task.config?.define || {};
   const dev = command === 'start';
@@ -82,7 +83,7 @@ export function createServerCompiler(options: Options) {
       // enable JSX syntax in .js files by default for compatible with migrate project
       // while it is not recommended
       loader: { '.js': 'jsx' },
-      inject: [path.resolve(__dirname, '../polyfills/react.js')],
+      inject: [path.resolve(__dirname, '../polyfills/react.js'), ...inject],
       ...buildOptions,
       define,
       plugins: [

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -7,6 +7,7 @@ import type { UnpluginOptions } from 'unplugin';
 import type Server from 'webpack-dev-server';
 import type { ECMA } from 'terser';
 import type { Config as CompilationConfig } from '@builder/swc';
+import type { BuildOptions } from 'esbuild';
 
 // get type definitions from terser-webpack-plugin
 interface CustomOptions {
@@ -115,4 +116,8 @@ export interface Config {
   logging?: string;
 
   enableReadPagePathFromAppContext?: boolean;
+
+  server?: {
+    buildOptions?: BuildOptions;
+  };
 }


### PR DESCRIPTION
支持在插件中修改 server 端的构建配置。

```ts
onGetConfig(config => {
  config.server = config.server || {};
  config.server = {
    buildOptions: {
       xxxx
    }
  }
})
```