### PR TITLE
fix: no main entryPoint

### DIFF
--- a/packages/ice/src/service/preBundleCJSDeps.ts
+++ b/packages/ice/src/service/preBundleCJSDeps.ts
@@ -114,7 +114,7 @@ function resolvePackageEntry(depId: string, rootDir: string) {
   // resolve exports cjs field
   let entryPoint = resolveExports(pkgJSONData, depId, { require: true });
   if (!entryPoint) {
-    entryPoint = pkgJSONData['main'];
+    entryPoint = pkgJSONData['main'] || 'index.js';
   }
   const entryPointPath = path.join(dir, entryPoint);
   return entryPointPath;


### PR DESCRIPTION
需要兼容类似 [lodash.debounce](https://unpkg.com/browse/lodash.debounce@4.0.8/) 包没有在 package.json 中指明入口，默认是根目录的 index.js 