### PR TITLE
fix: replace dash of route id when generate template

### DIFF
--- a/packages/ice/src/routes.ts
+++ b/packages/ice/src/routes.ts
@@ -111,7 +111,7 @@ function generateRouteConfig(
       const componentFile = file.replace(new RegExp(`${fileExtname}$`), '');
       const componentPath = path.isAbsolute(componentFile) ? componentFile : `@/pages/${componentFile}`;
 
-      const loaderName = `${exportKey}_${id}`.replace(/[-/]/, '_');
+      const loaderName = `${exportKey}_${id}`.replace(/[-/]/g, '_');
       const routePath = route.path || (route.index ? 'index' : '/');
       const fullPath = path.join(parentPath, routePath);
       imports.push([id, loaderName, fullPath]);

--- a/packages/ice/src/routes.ts
+++ b/packages/ice/src/routes.ts
@@ -111,7 +111,7 @@ function generateRouteConfig(
       const componentFile = file.replace(new RegExp(`${fileExtname}$`), '');
       const componentPath = path.isAbsolute(componentFile) ? componentFile : `@/pages/${componentFile}`;
 
-      const loaderName = `${exportKey}_${id}`.replace('/', '_');
+      const loaderName = `${exportKey}_${id}`.replace(/[-/]/, '_');
       const routePath = route.path || (route.index ? 'index' : '/');
       const fullPath = path.join(parentPath, routePath);
       imports.push([id, loaderName, fullPath]);


### PR DESCRIPTION
Fix: replace dash of route id when generate template