### PR TITLE
feat: pass server option to config transform

### DIFF
--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -10,7 +10,7 @@ import type {
 } from 'webpack-dev-server';
 import type { Options } from 'eslint-webpack-plugin';
 import type { ForkTsCheckerWebpackPluginOptions } from 'fork-ts-checker-webpack-plugin/lib/plugin-options';
-import type { UnpluginOptions } from 'unplugin';
+import type { UnpluginOptions, UnpluginContext } from 'unplugin';
 import type Server from 'webpack-dev-server';
 import type { ECMA } from 'terser';
 import type { Config as SWCCompilationConfig } from '@builder/swc';
@@ -39,6 +39,15 @@ interface SwcOptions {
 }
 
 type Experimental = Pick<Configuration, 'experiments'>;
+
+interface TransformOptions {
+  isServer: boolean;
+}
+type Transform = (this: UnpluginContext, code: string, id: string, options: TransformOptions) => ReturnType<UnpluginOptions['transform']>;
+
+interface TransformPlugin extends Omit<UnpluginOptions, 'transform'> {
+  transform?: Transform;
+}
 
 export type ModifyWebpackConfig = (config: Configuration, ctx: ConfigurationCtx) => Configuration;
 export interface Config {
@@ -73,9 +82,9 @@ export interface Config {
 
   hash?: boolean | string;
 
-  transformPlugins?: UnpluginOptions[];
+  transformPlugins?: TransformPlugin[];
 
-  transforms?: UnpluginOptions['transform'][];
+  transforms?: Transform[];
 
   middlewares?:
   | ((middlewares: Middleware[], devServer: Server) => Middleware[])


### PR DESCRIPTION
支持以下方式区分 server 构建逻辑：

```js
import { defineConfig } from '@ice/app';

export default defineConfig({
  transform: (code, id, { isServer }) => {
    if (isServer) {
      console.log('server');
    }
    return code;
  },
});
```