### PR TITLE
fix: the order of transform plugins

### DIFF
--- a/packages/webpack-config/src/getCompilerPlugins.ts
+++ b/packages/webpack-config/src/getCompilerPlugins.ts
@@ -41,6 +41,13 @@ function getCompilerPlugins(config: Config, compiler: Compiler) {
     new RegExp(SKIP_COMPILE.map((dep) => `node_modules/?.+${dep}/`).join('|')),
     /bundles\/compiled/,
   ];
+
+  // Add custom transform before swc compilation so the source code can be got before transformed.
+  compilerPlugins.push(
+    ...transformPlugins,
+    ...transforms.map((transform, index) => ({ name: `transform_${index}`, transform })),
+  );
+
   if (swcOptions) {
     compilerPlugins.push(compilationPlugin({
       sourceMap,
@@ -51,11 +58,6 @@ function getCompilerPlugins(config: Config, compiler: Compiler) {
       swcOptions,
     }));
   }
-
-  compilerPlugins.push(
-    ...transformPlugins,
-    ...transforms.map((transform, index) => ({ name: `transform_${index}`, transform })),
-  );
 
   return compiler === 'webpack'
     ? compilerPlugins.map(plugin => createUnplugin(() => getPluginTransform(plugin, 'webpack')).webpack())


### PR DESCRIPTION
re-order the transform plugins, so we can get the source code in user config `transform`