### PR TITLE
fix: ssr stream error recursion

### DIFF
--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -41,6 +41,7 @@ interface RenderOptions {
   // serverOnlyBasename is used when just want to change basename for server.
   serverOnlyBasename?: string;
   routePath?: string;
+  disableFallback?: boolean;
 }
 
 interface Piper {
@@ -74,6 +75,9 @@ export async function renderToHTML(requestContext: ServerContext, renderOptions:
       statusCode: 200,
     };
   } catch (error) {
+    if (renderOptions.disableFallback) {
+      throw error;
+    }
     console.error('Warning: piperToString error, downgrade to csr.', error);
     // downgrade to csr.
     const result = fallback();
@@ -101,6 +105,9 @@ export async function renderToResponse(requestContext: ServerContext, renderOpti
     try {
       await pipeToResponse(res, pipe);
     } catch (error) {
+      if (renderOptions.disableFallback) {
+        throw error;
+      }
       console.error('PiperToResponse error, downgrade to csr.', error);
       // downgrade to csr.
       const result = await fallback();

--- a/packages/runtime/src/server/streamRender.tsx
+++ b/packages/runtime/src/server/streamRender.tsx
@@ -14,19 +14,10 @@ export function renderToNodeStream(
   generateStaticHTML: boolean,
 ): NodeWritablePiper {
   return (res, next) => {
-    let shellReady = false;
-
-    const { abort, pipe } = ReactDOMServer.renderToPipeableStream(
+    const { pipe } = ReactDOMServer.renderToPipeableStream(
       element,
       {
-        onError(error: Error) {
-          if (!shellReady) {
-            next(error);
-          }
-          abort();
-        },
         onShellReady() {
-          shellReady = true;
           if (!generateStaticHTML) {
             pipe(res);
           }
@@ -36,6 +27,9 @@ export function renderToNodeStream(
             pipe(res);
           }
           next();
+        },
+        onError(error: Error) {
+          next(error);
         },
       },
     );


### PR DESCRIPTION
- 去掉 `abort()`，避免循环调用 `onError` 回调导致栈溢出
- 添加 disableFallback 参数，支持把错误交给方法调用时处理