### PR TITLE
chore: remove AppConfig extends index type

### DIFF
--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -43,7 +43,7 @@ export type GetStaticData = (ctx: RequestContext) => Promise<RouteData> | RouteD
 // route.getConfig
 export type GetConfig = (args: { data: RouteData }) => RouteConfig;
 
-export interface AppConfig extends Record<string, any> {
+export interface AppConfig {
   app?: App;
   router?: {
     type?: 'hash' | 'browser' | 'memory';


### PR DESCRIPTION
移除 AppConfig 继承的索引类型，避免在写 appConfig 时没有类型报错信息