### PR TITLE
fix: regex error for resolve aliased path

### DIFF
--- a/packages/ice/src/service/analyze.ts
+++ b/packages/ice/src/service/analyze.ts
@@ -34,7 +34,7 @@ export function resolveId(id: string, alias: Alias) {
     const strictKey = isStrict ? aliasKey.slice(0, -1) : aliasKey;
     const aliasValue = alias[aliasKey];
     if (!aliasValue) return false;
-    if (aliasValue.match(/.(j|t)s(x)?$/)) {
+    if (aliasValue.match(/\.(j|t)s(x)?$/)) {
       if (aliasedPath === strictKey) {
         aliasedPath = aliasValue;
         break;

--- a/packages/ice/tests/preAnalyze.test.ts
+++ b/packages/ice/tests/preAnalyze.test.ts
@@ -26,6 +26,11 @@ describe('resolveId', () => {
     const id = resolveId('ice', alias);
     expect(id).toBe(false);
   });
+  it('alias: { foundnamejs: \'/user/folder\'}; id: foundnamejs', () => {
+    const alias = { 'foundnamejs': '/user/folder' };
+    const id = resolveId('foundnamejs', alias);
+    expect(id).toBe('/user/folder');
+  });
 
   it('alias with relative path', () => {
     const alias = { ice: 'rax' } as Alias;


### PR DESCRIPTION
`/.(j|t)s(x)?$/` => `/\.(j|t)s(x)?$/`