### PR TITLE
fix: render client app basename

### DIFF
--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -33,7 +33,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
     routes,
     runtimeModules,
     Document,
-    basename: defaultBasename,
+    basename,
     hydrate,
     memoryRouter,
   } = options;
@@ -43,7 +43,6 @@ export default async function runClientApp(options: RunClientAppOptions) {
     routesData,
     routesConfig,
     assetsManifest,
-    basename: basenameFromServer,
     routePath,
   } = appContextFromServer;
 
@@ -55,7 +54,6 @@ export default async function runClientApp(options: RunClientAppOptions) {
 
   const appConfig = getAppConfig(app);
 
-  const basename = basenameFromServer || defaultBasename;
   const matches = matchRoutes(
     routes,
     memoryRouter ? routePath : window.location,


### PR DESCRIPTION
csr 的时候，不应该拿 serverOnlyBasename 作为 basename 进行路由匹配