### PR TITLE
Feat/compat maxlength

### DIFF
--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -39,6 +39,15 @@ function createInputCompat(type: string) {
       onInput && onInput(event.nativeEvent);
     }, [onInput]);
 
+    // Compat maxlength in rax-textinput, because maxlength is invalid props in web,it will be set attributes to element
+    // and react will Throw a warning in DEV.
+    // https://github.com/raxjs/rax-components/issues/459
+    // https://github.com/raxjs/rax-components/blob/master/packages/rax-textinput/src/index.tsx#L142
+    if (rest.maxlength) {
+      rest.maxLength = rest.maxlength;
+      delete rest.maxlength;
+    }
+
     return _createElement(type, {
       ...rest,
       value: v,
@@ -89,15 +98,6 @@ export function createElement<P extends {
     // and native input can also modify the value of self in Rax.
     // So we should compat input to InputCompat, the same as textarea.
     type = createInputCompat(type);
-
-    // Compat maxlength in rax-textinput, because maxlength is invalid props in web,it will be set attributes to element
-    // and react will Throw a warning in DEV.
-    // https://github.com/raxjs/rax-components/issues/459
-    // https://github.com/raxjs/rax-components/blob/master/packages/rax-textinput/src/index.tsx#L142
-    if (rest.maxlength) {
-      rest.maxLength = rest.maxlength;
-      delete rest.maxlength;
-    }
   }
 
   // Compat for visibility events.

--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -82,13 +82,22 @@ export function createElement<P extends {
     rest.style = compatStyleProps;
   }
 
-  // Setting the value of props makes the component be a controlled component in React.
-  // But setting the value is same as web in Rax.
-  // User can modify value of props to modify native input value
-  // and native input can also modify the value of self in Rax.
-  // So we should compat input to InputCompat, the same as textarea.
   if (type === 'input' || type === 'textarea') {
+    // Setting the value of props makes the component be a controlled component in React.
+    // But setting the value is same as web in Rax.
+    // User can modify value of props to modify native input value
+    // and native input can also modify the value of self in Rax.
+    // So we should compat input to InputCompat, the same as textarea.
     type = createInputCompat(type);
+
+    // Compat maxlength in rax-textinput, because maxlength is invalid props in web,it will be set attributes to element
+    // and react will Throw a warning in DEV.
+    // https://github.com/raxjs/rax-components/issues/459
+    // https://github.com/raxjs/rax-components/blob/master/packages/rax-textinput/src/index.tsx#L142
+    if (rest.maxlength) {
+      rest.maxLength = rest.maxlength;
+      delete rest.maxlength;
+    }
   }
 
   // Compat for visibility events.

--- a/packages/rax-compat/tests/createElement.test.tsx
+++ b/packages/rax-compat/tests/createElement.test.tsx
@@ -76,4 +76,19 @@ describe('createElement', () => {
     const node = wrapper.queryByTestId('valueTest');
     expect(node.value).toBe(str);
   });
+
+  it('input set empty string to maxlength not be 0', () => {
+    const str = 'hello world';
+    const wrapper = render(createElement(
+      'input',
+      {
+        'data-testid': 'maxlengthTest',
+        value: str,
+        maxlength: ''
+      },
+    ));
+
+    const node = wrapper.queryByTestId('valueTest');
+    expect(node?.getAttribute('maxlength')).toBe(null);
+  });
 });


### PR DESCRIPTION
兼容 maxlength 的情况，使其回归 Web 标准，通过 props 而不是 attribute 设置 maxLength 属性。
同时，保证 Rax 迁移工程设置空字符串行为符合之前预期，不需要上层业务修改。
https://github.com/raxjs/rax-components/issues/459