### PR TITLE
fix: should get eventTarget by _nativeNode

### DIFF
--- a/packages/rax-compat/src/create-element.ts
+++ b/packages/rax-compat/src/create-element.ts
@@ -120,16 +120,19 @@ function VisibilityChange({
 
   const listen = useCallback((eventName: string, handler: Function) => {
     const { current } = ref;
-    if (current != null) {
-      if (isFunction(handler)) {
-        observerElement(current as HTMLElement);
-        current.addEventListener(eventName, handler);
-      }
+    // Rax components will set custom ref by useImperativeHandle.
+    // So We should get eventTarget by _nativeNode.
+    // https://github.com/raxjs/rax-components/blob/master/packages/rax-textinput/src/index.tsx#L151
+    if (current && isFunction(handler)) {
+      const eventTarget = current._nativeNode || current;
+      observerElement(eventTarget as HTMLElement);
+      eventTarget.addEventListener(eventName, handler);
     }
     return () => {
       const { current } = ref;
       if (current) {
-        current.removeEventListener(eventName, handler);
+        const eventTarget = current._nativeNode || current;
+        eventTarget.removeEventListener(eventName, handler);
       }
     };
   }, [ref]);


### PR DESCRIPTION
兼容 rax-components 中通过 useImperativeHandle 对 ref 进行自定义导致无法访问正确的 eventTarget 的情况。