### PR TITLE
chore: remove unused constants.ts

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,4 +1,0 @@
-export const ICE_PKG_PACKAGES = [
-  'rax-compat',
-  'jsx-runtime',
-];


### PR DESCRIPTION
这个数组之前是用于本地调试（npm run watch）的时候 ice-pkg 的包使用单独构建，其他使用 tsc 构建。现在统一走 pnpm monorepo 构建，故此文件没用了