### PR TITLE
fix: hash router fail when no index route

### DIFF
--- a/packages/ice/src/middlewares/ssr/renderMiddleware.ts
+++ b/packages/ice/src/middlewares/ssr/renderMiddleware.ts
@@ -27,7 +27,8 @@ export default function createRenderMiddleware(options: Options): Middleware {
     const routes = JSON.parse(fse.readFileSync(routeManifestPath, 'utf-8'));
     const basename = getRouterBasename(taskConfig, (await getAppConfig()).default);
     const matches = matchRoutes(routes, req.path, basename);
-    if (matches.length) {
+    // When documentOnly is true, it means that the app is CSR and it should return the html.
+    if (matches.length || documentOnly) {
       // Wait for the server compilation to finish
       const { serverEntry, error } = await serverCompileTask.get();
       if (error) {

--- a/packages/ice/src/service/webpackCompiler.ts
+++ b/packages/ice/src/service/webpackCompiler.ts
@@ -95,20 +95,22 @@ async function webpackCompiler(options: {
       consola.warn(messages.warnings.join('\n'));
     }
     if (command === 'start') {
+      const appConfig = (await hooksAPI.getAppConfig()).default;
+      const hashChar = appConfig?.router?.type === 'hash' ? '#/' : '';
       if (isSuccessful && isFirstCompile) {
         let logoutMessage = '\n';
         logoutMessage += chalk.green(' Starting the development server at:');
         if (process.env.CLOUDIDE_ENV) {
-          logoutMessage += `\n   - IDE server: https://${process.env.WORKSPACE_UUID}-${commandArgs.port}.${process.env.WORKSPACE_HOST}${devPath}`;
+          logoutMessage += `\n   - IDE server: https://${process.env.WORKSPACE_UUID}-${commandArgs.port}.${process.env.WORKSPACE_HOST}${hashChar}${devPath}`;
         } else {
           logoutMessage += `\n
-   - Local  : ${chalk.underline.white(`${urls.localUrlForBrowser}${devPath}`)}
-   - Network:  ${chalk.underline.white(`${urls.lanUrlForTerminal}${devPath}`)}`;
+   - Local  : ${chalk.underline.white(`${urls.localUrlForBrowser}${hashChar}${devPath}`)}
+   - Network:  ${chalk.underline.white(`${urls.lanUrlForTerminal}${hashChar}${devPath}`)}`;
         }
         consola.log(`${logoutMessage}\n`);
 
         if (commandArgs.open) {
-          openBrowser(`${urls.localUrlForBrowser}${devPath}`);
+          openBrowser(`${urls.localUrlForBrowser}${hashChar}${devPath}`);
         }
       }
       // compiler.hooks.done is AsyncSeriesHook which does not support async function


### PR DESCRIPTION
- fix: 当没有根路由时，dev 的时候访问页面时报 404 的错误
- fix: 开启 hash 路由时，在控制台打印的 URL 没有带上 # 字符