### PR TITLE
fix: lock regenerate-runtime path

### DIFF
--- a/examples/basic-project/package.json
+++ b/examples/basic-project/package.json
@@ -22,7 +22,6 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.2",
     "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9",
     "speed-measure-webpack-plugin": "^1.5.0",
     "webpack": "^5.73.0"
   }

--- a/examples/csr-project/package.json
+++ b/examples/csr-project/package.json
@@ -20,7 +20,6 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9",
     "speed-measure-webpack-plugin": "^1.5.0",
     "webpack": "^5.73.0"
   }

--- a/examples/hash-router/package.json
+++ b/examples/hash-router/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "regenerator-runtime": "^0.13.9"
+    "@types/react-dom": "^18.0.0"
   }
 }

--- a/examples/rax-project/package.json
+++ b/examples/rax-project/package.json
@@ -24,7 +24,6 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.2",
     "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9",
     "webpack": "^5.73.0"
   }
 }

--- a/examples/routes-generate/package.json
+++ b/examples/routes-generate/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9"
+    "browserslist": "^4.19.3"
   }
 }

--- a/examples/with-antd-mobile/package.json
+++ b/examples/with-antd-mobile/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.2",
-    "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9"
+    "browserslist": "^4.19.3"
   }
 }

--- a/examples/with-antd/package.json
+++ b/examples/with-antd/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.2",
-    "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9"
+    "browserslist": "^4.19.3"
   }
 }

--- a/examples/with-fusion/package.json
+++ b/examples/with-fusion/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.2",
-    "regenerator-runtime": "^0.13.9"
+    "@types/react-dom": "^18.0.2"
   }
 }

--- a/examples/with-pha/package.json
+++ b/examples/with-pha/package.json
@@ -19,7 +19,6 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.2",
     "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9",
     "webpack": "^5.73.0"
   }
 }

--- a/examples/with-store/package.json
+++ b/examples/with-store/package.json
@@ -15,7 +15,6 @@
     "@ice/plugin-store": "workspace:*",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "browserslist": "^4.19.3",
-    "regenerator-runtime": "^0.13.9"
+    "browserslist": "^4.19.3"
   }
 }

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -63,6 +63,7 @@
     "open": "^8.4.0",
     "path-to-regexp": "^6.2.0",
     "react-router": "^6.3.0",
+    "regenerator-runtime": "^0.13.9",
     "resolve.exports": "^1.1.0",
     "sass": "^1.49.9",
     "semver": "^7.3.5",
@@ -71,8 +72,8 @@
     "webpack-dev-server": "^4.7.4"
   },
   "devDependencies": {
-    "@types/babel__traverse": "^7.17.1",
     "@types/babel__generator": "^7.6.4",
+    "@types/babel__traverse": "^7.17.1",
     "@types/cross-spawn": "^6.0.2",
     "@types/ejs": "^3.1.0",
     "@types/estree": "^0.0.51",

--- a/packages/ice/src/createService.ts
+++ b/packages/ice/src/createService.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { Context } from 'build-scripts';
 import consola from 'consola';
 import type { CommandArgs, CommandName } from 'build-scripts';
@@ -27,6 +28,7 @@ import { getAppExportConfig, getRouteExportConfig } from './service/config.js';
 import renderExportsTemplate from './utils/renderExportsTemplate.js';
 import { getFileExports } from './service/analyze.js';
 
+const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface CreateServiceOptions {
@@ -98,7 +100,13 @@ async function createService({ rootDir, command, commandArgs }: CreateServiceOpt
 
   let taskConfigs = await ctx.setup();
   // merge task config with built-in config
-  taskConfigs = mergeTaskConfig(taskConfigs, { port: commandArgs.port });
+  taskConfigs = mergeTaskConfig(taskConfigs, {
+    port: commandArgs.port,
+    alias: {
+      // Get absolute path of `regenerator-runtime`, so it's unnecessary to add it to project dependencies
+      'regenerator-runtime': require.resolve('regenerator-runtime'),
+    },
+  });
   const webTaskConfig = taskConfigs.find(({ name }) => name === 'web');
 
   // get userConfig after setup because of userConfig maybe modified by plugins

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -24,7 +24,6 @@
     "magic-string": "^0.26.1",
     "mini-css-extract-plugin": "2.6.0",
     "react-refresh": "^0.12.0",
-    "regenerator-runtime": "0.13.9",
     "unplugin": "^0.3.2"
   },
   "devDependencies": {

--- a/packages/webpack-config/src/unPlugins/compilation.ts
+++ b/packages/webpack-config/src/unPlugins/compilation.ts
@@ -7,7 +7,6 @@ import type { Config } from '@ice/types';
 
 const { merge } = lodash;
 const require = createRequire(import.meta.url);
-const regeneratorRuntimePath = require.resolve('regenerator-runtime');
 
 type JSXSuffix = 'jsx' | 'tsx';
 
@@ -131,10 +130,6 @@ function getJsxTransformOptions({
       transform: {
         react: reactTransformConfig,
         legacyDecorator: true,
-        // @ts-expect-error fix me when @builder/swc fix type error
-        regenerator: {
-          importPath: regeneratorRuntimePath,
-        },
       },
       externalHelpers: false,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,6 @@ importers:
       browserslist: ^4.19.3
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
       speed-measure-webpack-plugin: ^1.5.0
       webpack: ^5.73.0
     dependencies:
@@ -103,7 +102,6 @@ importers:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
       browserslist: 4.20.3
-      regenerator-runtime: 0.13.9
       speed-measure-webpack-plugin: 1.5.0_webpack@5.73.0
       webpack: 5.73.0
 
@@ -118,7 +116,6 @@ importers:
       browserslist: ^4.19.3
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
       speed-measure-webpack-plugin: ^1.5.0
       webpack: ^5.73.0
     dependencies:
@@ -132,7 +129,6 @@ importers:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
       browserslist: 4.20.3
-      regenerator-runtime: 0.13.9
       speed-measure-webpack-plugin: 1.5.0_webpack@5.73.0
       webpack: 5.73.0
 
@@ -144,7 +140,6 @@ importers:
       '@types/react-dom': ^18.0.0
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/runtime': link:../../packages/runtime
@@ -153,7 +148,6 @@ importers:
     devDependencies:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
-      regenerator-runtime: 0.13.9
 
   examples/rax-project:
     specifiers:
@@ -170,7 +164,6 @@ importers:
       rax-view: ^2.3.0
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
       webpack: ^5.73.0
     dependencies:
       '@ice/app': link:../../packages/ice
@@ -187,7 +180,6 @@ importers:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
       browserslist: 4.20.3
-      regenerator-runtime: 0.13.9
       webpack: 5.73.0
 
   examples/routes-generate:
@@ -199,7 +191,6 @@ importers:
       browserslist: ^4.19.3
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/runtime': link:../../packages/runtime
@@ -209,7 +200,6 @@ importers:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
       browserslist: 4.20.3
-      regenerator-runtime: 0.13.9
 
   examples/single-route:
     specifiers:
@@ -245,7 +235,6 @@ importers:
       moment: ^2.29.4
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/plugin-antd': link:../../packages/plugin-antd
@@ -259,7 +248,6 @@ importers:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
       browserslist: 4.20.3
-      regenerator-runtime: 0.13.9
 
   examples/with-antd-mobile:
     specifiers:
@@ -272,7 +260,6 @@ importers:
       constate: ^3.3.2
       react: ^18.2.0
       react-dom: ^18.2.0
-      regenerator-runtime: ^0.13.9
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/runtime': link:../../packages/runtime
@@ -284,7 +271,6 @@ importers:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
       browserslist: 4.20.3
-      regenerator-runtime: 0.13.9
 
   examples/with-fusion:
     specifiers:
@@ -296,7 +282,6 @@ importers:
       '@types/react-dom': ^18.0.2
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
     dependencies:
       '@alifd/next': 1.25.49_biqbaboplfbrettd7655fr4n2y
       '@ice/app': link:../../packages/ice
@@ -307,7 +292,6 @@ importers:
     devDependencies:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
-      regenerator-runtime: 0.13.9
 
   examples/with-pha:
     specifiers:
@@ -319,7 +303,6 @@ importers:
       browserslist: ^4.19.3
       react: ^18.0.0
       react-dom: ^18.0.0
-      regenerator-runtime: ^0.13.9
       webpack: ^5.73.0
     dependencies:
       '@ice/app': link:../../packages/ice
@@ -331,7 +314,6 @@ importers:
       '@types/react': 18.0.8
       '@types/react-dom': 18.0.3
       browserslist: 4.20.3
-      regenerator-runtime: 0.13.9
       webpack: 5.73.0
 
   examples/with-store:
@@ -342,7 +324,6 @@ importers:
       '@types/react': ^18.0.0
       '@types/react-dom': ^18.0.0
       browserslist: ^4.19.3
-      regenerator-runtime: ^0.13.9
     dependencies:
       '@ice/app': link:../../packages/ice
       '@ice/runtime': link:../../packages/runtime
@@ -351,7 +332,6 @@ importers:
       '@types/react': 18.0.15
       '@types/react-dom': 18.0.6
       browserslist: 4.21.3
-      regenerator-runtime: 0.13.9
 
   packages/bundles:
     specifiers:
@@ -486,6 +466,7 @@ importers:
       path-to-regexp: ^6.2.0
       react: ^18.0.0
       react-router: ^6.3.0
+      regenerator-runtime: ^0.13.9
       resolve.exports: ^1.1.0
       sass: ^1.49.9
       semver: ^7.3.5
@@ -529,6 +510,7 @@ importers:
       open: 8.4.0
       path-to-regexp: 6.2.1
       react-router: 6.3.0_react@18.2.0
+      regenerator-runtime: 0.13.9
       resolve.exports: 1.1.0
       sass: 1.50.1
       semver: 7.3.7
@@ -775,7 +757,6 @@ importers:
       magic-string: ^0.26.1
       mini-css-extract-plugin: 2.6.0
       react-refresh: ^0.12.0
-      regenerator-runtime: 0.13.9
       unplugin: ^0.3.2
       webpack: ^5.73.0
       webpack-dev-server: ^4.7.4
@@ -792,7 +773,6 @@ importers:
       magic-string: 0.26.1
       mini-css-extract-plugin: 2.6.0_webpack@5.73.0
       react-refresh: 0.12.0
-      regenerator-runtime: 0.13.9
       unplugin: 0.3.3_4upc34oiflw3lduyjvrzpjntau
     devDependencies:
       '@ice/types': link:../types


### PR DESCRIPTION
Config `regenerator.importPath` is not supported by @swc/core (while @builder/swc is supported), use absolute alias path for `regenerate-runtime`.