### PR TITLE
fix: fix relative path of alias

### DIFF
--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -90,10 +90,10 @@ const getWebpackConfig: GetWebpackConfig = ({ rootDir, config, webpack, runtimeT
   const dev = mode !== 'production';
   const supportedBrowsers = getSupportedBrowsers(rootDir, dev);
   const hashKey = hash === true ? 'hash:8' : (hash || '');
-  // formate alias
+  // format alias
   const aliasWithRoot = {};
   Object.keys(alias).forEach((key) => {
-    aliasWithRoot[key] = alias[key] && alias[key].startsWith('.') ? path.join(rootDir, alias[key]) : alias[key];
+    aliasWithRoot[key] = alias[key] && !path.isAbsolute(alias[key]) ? path.join(rootDir, alias[key]) : alias[key];
   });
 
   // auto stringify define value


### PR DESCRIPTION
兼容 rax 工程转移过来，非 . 开头的相对路径的 alias

such as { "alias": { "@components": "src/components/" } }