### PR TITLE
fix: transform component name

### DIFF
--- a/packages/style-import/src/index.ts
+++ b/packages/style-import/src/index.ts
@@ -6,13 +6,14 @@ interface TransformOptions {
   libraryName: string;
   style: ((name: string) => string) | Boolean;
   sourceMap?: Boolean;
+  toKebab?: Boolean;
 }
 
 export async function importStyle(code: string, options: TransformOptions): Promise<null | {
   code: string;
   map: ReturnType<MagicString['generateMap']>;
 }> {
-  const { style, libraryName, sourceMap } = options;
+  const { style, libraryName, sourceMap, toKebab = true } = options;
   if (!style) {
     return null;
   }
@@ -45,7 +46,12 @@ export async function importStyle(code: string, options: TransformOptions): Prom
           console.log(e);
           return;
         }
-        exports.forEach(({ n: importName }) => {
+        exports.forEach(({ n }) => {
+          const toKebabCase = (str: string) => str.replace(/^[A-Z]/, $1 => $1.toLowerCase()).replace(/([A-Z])/g, $1 => `-${$1.toLowerCase()}`);
+          let importName = n;
+          if (toKebab) {
+             importName = toKebabCase(importName);
+          }
           const stylePath = typeof style === 'function' ? style(importName) : `${libraryName}/es/${importName}/style`;
           if (stylePath) {
             styleStatements.push(`import '${stylePath}';`);

--- a/packages/style-import/src/index.ts
+++ b/packages/style-import/src/index.ts
@@ -6,14 +6,14 @@ interface TransformOptions {
   libraryName: string;
   style: ((name: string) => string) | Boolean;
   sourceMap?: Boolean;
-  toKebab?: Boolean;
+  kebabCase?: Boolean;
 }
 
 export async function importStyle(code: string, options: TransformOptions): Promise<null | {
   code: string;
   map: ReturnType<MagicString['generateMap']>;
 }> {
-  const { style, libraryName, sourceMap, toKebab = true } = options;
+  const { style, libraryName, sourceMap, kebabCase = true } = options;
   if (!style) {
     return null;
   }
@@ -49,7 +49,7 @@ export async function importStyle(code: string, options: TransformOptions): Prom
         exports.forEach(({ n }) => {
           const toKebabCase = (str: string) => str.replace(/^[A-Z]/, $1 => $1.toLowerCase()).replace(/([A-Z])/g, $1 => `-${$1.toLowerCase()}`);
           let importName = n;
-          if (toKebab) {
+          if (kebabCase) {
              importName = toKebabCase(importName);
           }
           const stylePath = typeof style === 'function' ? style(importName) : `${libraryName}/es/${importName}/style`;


### PR DESCRIPTION
处理组件名称未转换为短横线式，导致引入样式异常问题

统一在 style-import 中将名称转换为短横线式，增加了 toKebab 参数来控制是否对名称进行转换，默认开启