### PR TITLE
fix: remove code of top level expression

### DIFF
--- a/packages/ice/src/utils/babelPluginRemoveCode.ts
+++ b/packages/ice/src/utils/babelPluginRemoveCode.ts
@@ -92,8 +92,10 @@ const removeTopLevelCode = (keepExports: string[] = []) => {
     ExpressionStatement: {
       enter(nodePath: NodePath<t.ExpressionStatement>) {
         // Remove top level call expression.
-        if (nodePath.parentPath.isProgram() && t.isCallExpression(nodePath.node.expression)) {
-          nodePath.remove();
+        if (nodePath.parentPath.isProgram()) {
+          if (t.isCallExpression(nodePath.node.expression) || t.isAssignmentExpression(nodePath.node.expression)) {
+            nodePath.remove();
+          }
         }
       },
     },

--- a/packages/ice/tests/fixtures/removeCode/expression.ts
+++ b/packages/ice/tests/fixtures/removeCode/expression.ts
@@ -1,0 +1,2 @@
+const a = {};
+a.test = 1;

--- a/packages/ice/tests/removeTopLevelCode.test.ts
+++ b/packages/ice/tests/removeTopLevelCode.test.ts
@@ -85,4 +85,11 @@ describe('remove top level code', () => {
     const content = generate(ast).code;
     expect(content.replace(/\n/g, '').replace(/\s+/g, ' ')).toBe(`const a = 1;export default a;`);
   });
+
+  it('remove expression statement', () => {
+    const ast = parse(fs.readFileSync(path.join(__dirname, './fixtures/removeCode/expression.ts'), 'utf-8'), parserOptions);
+    traverse(ast, removeTopLevelCodePlugin(['default']));
+    const content = generate(ast).code;
+    expect(content.replace(/\n/g, '').replace(/\s+/g, ' ')).toBe('');
+  });
 })


### PR DESCRIPTION
fix remove case of `ExpressionStatement`