### PR TITLE
test: fix routes-generate unit test timeout

### DIFF
--- a/tests/integration/app-config.test.ts
+++ b/tests/integration/app-config.test.ts
@@ -22,12 +22,12 @@ describe(`start ${example}`, () => {
     const res = await setupStartBrowser({ server: devServer, port });
     page = res.page;
     browser = res.browser;
-    await page.push('ice');
+    await page.push('/ice');
     expect(await page.$$text('h1')).toStrictEqual(['home']);
   }, 120000);
 
   test('error page', async () => {
-    await page.push('ice/error');
+    await page.push('/ice/error');
     await page.waitForNetworkIdle();
     expect(await page.$$text('h1')).toStrictEqual(['Something went wrong.']);
   }, 120000);

--- a/tests/integration/basic-project.test.ts
+++ b/tests/integration/basic-project.test.ts
@@ -113,7 +113,7 @@ describe(`start ${example}`, () => {
       await page.$$attr('meta[name="theme-color"]', 'content'),
     ).toStrictEqual(['#000']);
 
-    await page.push('about');
+    await page.push('/about');
     await page.waitForNetworkIdle();
 
     expect(

--- a/tests/integration/routes-generate.test.ts
+++ b/tests/integration/routes-generate.test.ts
@@ -2,16 +2,18 @@ import { expect, test, describe, afterAll } from 'vitest';
 import { buildFixture, setupBrowser } from '../utils/build';
 import { startFixture, setupStartBrowser } from '../utils/start';
 import type { Page } from '../utils/browser';
+import type Browser from '../utils/browser';
 
 const example = 'routes-generate';
 
 describe(`build ${example}`, () => {
-  let page: Page = null;
-  let browser = null;
+  let page: Page;
+  let browser: Browser;
+  const defaultHtml = 'index.html';
 
   test('open /', async () => {
     await buildFixture(example);
-    const res = await setupBrowser({ example });
+    const res = await setupBrowser({ example, defaultHtml });
     page = res.page;
     browser = res.browser;
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
@@ -19,30 +21,22 @@ describe(`build ${example}`, () => {
   }, 120000);
 
   test('define extra routes', async () => {
-    let res = await setupBrowser({ example, defaultHtml: 'about-me.html' });
-    page = res.page;
-    browser = res.browser;
+    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'about-me.html'));
     expect(await page.$$text('h1')).toStrictEqual([]);
     expect(await page.$$text('h2')).toStrictEqual(['About']);
 
-    res = await setupBrowser({ example, defaultHtml: 'product.html' });
-    page = res.page;
-    browser = res.browser;
+    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'product.html'));
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Products Page']);
   });
 
   test('page layout', async () => {
-    let res = await setupBrowser({ example, defaultHtml: 'dashboard/a.html' });
-    page = res.page;
-    browser = res.browser;
+    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'dashboard/a.html'));
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Dashboard']);
     expect(await page.$$text('h3')).toStrictEqual(['A page']);
 
-    res = await setupBrowser({ example, defaultHtml: 'dashboard/b.html' });
-    page = res.page;
-    browser = res.browser;
+    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'dashboard/b.html'));
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Dashboard']);
     expect(await page.$$text('h3')).toStrictEqual(['B page']);
@@ -57,10 +51,10 @@ describe(`build ${example}`, () => {
 });
 
 describe(`start ${example}`, () => {
-  let page: Page = null;
-  let browser = null;
+  let page: Page;
+  let browser: Browser;
 
-  test('setup devServer', async () => {
+  test('open /', async () => {
     const { devServer, port } = await startFixture(example);
     const res = await setupStartBrowser({ server: devServer, port });
     page = res.page;

--- a/tests/integration/routes-generate.test.ts
+++ b/tests/integration/routes-generate.test.ts
@@ -9,11 +9,10 @@ const example = 'routes-generate';
 describe(`build ${example}`, () => {
   let page: Page;
   let browser: Browser;
-  const defaultHtml = 'index.html';
 
   test('open /', async () => {
     await buildFixture(example);
-    const res = await setupBrowser({ example, defaultHtml });
+    const res = await setupBrowser({ example });
     page = res.page;
     browser = res.browser;
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
@@ -21,22 +20,22 @@ describe(`build ${example}`, () => {
   }, 120000);
 
   test('define extra routes', async () => {
-    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'about-me.html'));
+    await page.push('/about-me.html');
     expect(await page.$$text('h1')).toStrictEqual([]);
     expect(await page.$$text('h2')).toStrictEqual(['About']);
 
-    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'product.html'));
+    await page.push('/product.html');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Products Page']);
   });
 
   test('page layout', async () => {
-    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'dashboard/a.html'));
+    await page.push('/dashboard/a.html');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Dashboard']);
     expect(await page.$$text('h3')).toStrictEqual(['A page']);
 
-    await page.goto(page.baseUrl.replace(RegExp(`${defaultHtml}$`), 'dashboard/b.html'));
+    await page.push('/dashboard/b.html');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Dashboard']);
     expect(await page.$$text('h3')).toStrictEqual(['B page']);
@@ -64,33 +63,33 @@ describe(`start ${example}`, () => {
   }, 120000);
 
   test('define extra routes', async () => {
-    await page.push('about-me');
+    await page.push('/about-me');
     expect(await page.$$text('h1')).toStrictEqual([]);
     expect(await page.$$text('h2')).toStrictEqual(['About']);
 
-    await page.push('product');
+    await page.push('/product');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Products Page']);
   });
 
   test('page layout', async () => {
-    await page.push('dashboard/a');
+    await page.push('/dashboard/a');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Dashboard']);
     expect(await page.$$text('h3')).toStrictEqual(['A page']);
 
-    await page.push('dashboard/b');
+    await page.push('/dashboard/b');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Dashboard']);
     expect(await page.$$text('h3')).toStrictEqual(['B page']);
   });
 
   test('dynamic routes layout', async () => {
-    await page.push('detail/a');
+    await page.push('/detail/a');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Detail id: a']);
 
-    await page.push('detail/b');
+    await page.push('/detail/b');
     expect(await page.$$text('h1')).toStrictEqual(['Layout']);
     expect(await page.$$text('h2')).toStrictEqual(['Detail id: b']);
   });

--- a/tests/utils/build.ts
+++ b/tests/utils/build.ts
@@ -43,7 +43,7 @@ export const setupBrowser: SetupBrowser = async (options) => {
   console.log();
   // When preview html generate by build, the path will not match the router info,
   // so hydrate will not found the route component.
-  const page = await browser.page(`http://127.0.0.1:${port}/${defaultHtml}`, disableJS);
+  const page = await browser.page(`http://127.0.0.1:${port}`, `/${defaultHtml}`, disableJS);
   return {
     browser,
     page,

--- a/tests/utils/start.ts
+++ b/tests/utils/start.ts
@@ -47,10 +47,10 @@ commandArgs: {
 };
 
 export const setupStartBrowser: SetupBrowser = async (options) => {
-  const { port, server, defaultPath = '' } = options;
+  const { port, server, defaultPath = '/' } = options;
   const browser = new Browser({ server });
   await browser.start();
-  const page = await browser.page(`http://127.0.0.1:${port}/${defaultPath}`);
+  const page = await browser.page(`http://127.0.0.1:${port}`, defaultPath);
   return {
     browser,
     page,


### PR DESCRIPTION
在 windows CI 环境下，有可能出现 routes-generate 的单测用例超时的情况，目前优化减少 setupBrowser 的次数

https://github.com/ice-lab/ice-next/actions/runs/3065194845/jobs/4949054085

![image](https://user-images.githubusercontent.com/44047106/190551675-6feb923d-adc4-43e5-8905-a081bb8382a8.png)
