### PR TITLE
fix: disable hydrate when downgrade

### DIFF
--- a/packages/runtime/src/Document.tsx
+++ b/packages/runtime/src/Document.tsx
@@ -89,6 +89,7 @@ export function Scripts(props: React.ScriptHTMLAttributes<HTMLScriptElement>) {
     routeModules,
     routePath,
     basename,
+    documentOnly,
   };
 
   return (

--- a/packages/runtime/src/Document.tsx
+++ b/packages/runtime/src/Document.tsx
@@ -63,7 +63,9 @@ export function Links(props: React.LinkHTMLAttributes<HTMLLinkElement>) {
 }
 
 export function Scripts(props: React.ScriptHTMLAttributes<HTMLScriptElement>) {
-  const { routesData, routesConfig, matches, assetsManifest, documentOnly, routeModules, basename } = useAppContext();
+  const {
+    routesData, routesConfig, matches, assetsManifest, documentOnly, routeModules, basename, downgrade,
+  } = useAppContext();
   const appData = useAppData();
 
   const routeScripts = getScripts(matches, routesConfig);
@@ -90,6 +92,7 @@ export function Scripts(props: React.ScriptHTMLAttributes<HTMLScriptElement>) {
     routePath,
     basename,
     documentOnly,
+    downgrade,
   };
 
   return (

--- a/packages/runtime/src/Document.tsx
+++ b/packages/runtime/src/Document.tsx
@@ -91,7 +91,6 @@ export function Scripts(props: React.ScriptHTMLAttributes<HTMLScriptElement>) {
     routeModules,
     routePath,
     basename,
-    documentOnly,
     downgrade,
   };
 

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -45,6 +45,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
     routesConfig,
     assetsManifest,
     routePath,
+    documentOnly,
   } = appContextFromServer;
 
   const requestContext = getRequestContext(window.location);
@@ -88,7 +89,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
 
   const runtime = new Runtime(appContext);
 
-  if (hydrate) {
+  if (hydrate && !documentOnly) {
     runtime.setRender((container, element) => {
       ReactDOM.hydrateRoot(container, element);
     });

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -45,7 +45,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
     routesConfig,
     assetsManifest,
     routePath,
-    documentOnly,
+    downgrade,
   } = appContextFromServer;
 
   const requestContext = getRequestContext(window.location);
@@ -89,7 +89,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
 
   const runtime = new Runtime(appContext);
 
-  if (hydrate && !documentOnly) {
+  if (hydrate && !downgrade) {
     runtime.setRender((container, element) => {
       ReactDOM.hydrateRoot(container, element);
     });

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -185,7 +185,7 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
       throw err;
     }
     console.error('Warning: render server entry error, downgrade to csr.', err);
-    return renderDocument({ matches, routePath, renderOptions, routeModules: {} });
+    return renderDocument({ matches, routePath, renderOptions, routeModules: {}, downgrade: true });
   }
 }
 
@@ -285,7 +285,7 @@ async function renderServerEntry(
   const pipe = renderToNodeStream(element, false);
 
   const fallback = () => {
-    return renderDocument({ matches, routePath, renderOptions, routeModules });
+    return renderDocument({ matches, routePath, renderOptions, routeModules, downgrade: true });
   };
 
   return {
@@ -301,11 +301,14 @@ interface RenderDocumentOptions {
   routeModules: RouteModules;
   renderOptions: RenderOptions;
   routePath?: string;
+  downgrade?: boolean;
 }
 /**
  * Render Document for CSR.
  */
-function renderDocument({ matches, routeModules, renderOptions, routePath }: RenderDocumentOptions): RenderResult {
+function renderDocument(options: RenderDocumentOptions): RenderResult {
+  const { matches, routeModules, renderOptions, routePath, downgrade }: RenderDocumentOptions = options;
+
   const {
     routes,
     assetsManifest,
@@ -331,6 +334,7 @@ function renderDocument({ matches, routeModules, renderOptions, routePath }: Ren
     routeModules,
     routePath,
     basename,
+    downgrade,
   };
 
   const documentContext = {

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -78,6 +78,7 @@ export interface AppContext {
   matchedIds?: string[];
   appExport?: AppExport;
   basename?: string;
+  downgrade?: boolean;
 }
 
 export type Renderer = (


### PR DESCRIPTION
当 SSR 降到到 CSR 时，Client 端同时切换 hydrate 为 render