### PR TITLE
feat: support static runtime

### DIFF
--- a/examples/with-plugin-request/ice.config.mts
+++ b/examples/with-plugin-request/ice.config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from '@ice/app';
 import request from '@ice/plugin-request';
 
 export default defineConfig({
+  dataLoader: false,
   plugins: [
     request(),
   ],

--- a/examples/with-plugin-request/src/app.tsx
+++ b/examples/with-plugin-request/src/app.tsx
@@ -1,4 +1,6 @@
+import { request as requestAPI } from 'ice';
 import { defineRequestConfig } from '@ice/plugin-request/esm/types';
+
 const requestConfig = {
   // 可选的，全局设置 request 是否返回 response 对象，默认为 false
   withFullResponse: false,
@@ -49,6 +51,14 @@ const requestConfig = {
     },
   },
 };
+
+export async function getAppData() {
+  try {
+    return await requestAPI('/user');
+  } catch (err) {
+    console.log('request error', err);
+  }
+}
 
 export default {
   app: {

--- a/packages/ice/templates/core/entry.client.ts.ejs
+++ b/packages/ice/templates/core/entry.client.ts.ejs
@@ -1,6 +1,6 @@
 import { runClientApp, getAppConfig } from '<%- iceRuntimePath %>';
+import { commons, statics } from './runtimeModules';
 import * as app from '@/app';
-import runtimeModules from './runtimeModules';
 <% if (enableRoutes) { %>
 import routes from './routes';
 <% } %>
@@ -11,7 +11,10 @@ const getRouterBasename = () => {
 
 runClientApp({
   app,
-  runtimeModules,
+  runtimeModules: {
+    commons,
+    statics,
+  },
   <% if (enableRoutes) { %>routes,<% } %>
   basename: getRouterBasename(),
   hydrate: <%- hydrate %>,

--- a/packages/ice/templates/core/entry.server.ts.ejs
+++ b/packages/ice/templates/core/entry.server.ts.ejs
@@ -1,13 +1,15 @@
 import './env.server';
 import * as runtime from '@ice/runtime/server';
+import { commons, statics } from './runtimeModules';
 import * as app from '@/app';
-import runtimeModules from './runtimeModules';
 import Document from '@/document';
 import type { RenderMode } from '@ice/runtime';
 // @ts-ignore
 import assetsManifest from 'virtual:assets-manifest.json';
 import routes from './routes';
 import routesConfig from './routes-config.bundle.mjs';
+
+const runtimeModules = { commons, statics };
 
 const getRouterBasename = () => {
   const appConfig = runtime.getAppConfig(app);

--- a/packages/ice/templates/core/runtimeModules.ts.ejs
+++ b/packages/ice/templates/core/runtimeModules.ts.ejs
@@ -1,15 +1,25 @@
 <% const moduleNames = []; -%>
-<% if (runtimeModules.length) {-%>
-  <% runtimeModules.filter((moduleInfo) => !moduleInfo.staticModule).forEach((runtimeModule, index) => { -%>
-    <% moduleNames.push('module' + index) %>
+<% const staticModuleNames = []; -%>
+<% if (runtimeModules.length) { -%>
+<% runtimeModules.forEach((runtimeModule, index) => { -%>
 import module<%= index %> from '<%= runtimeModule.path %>';
+    <% if (runtimeModule.staticRuntime) { -%>
+      <% staticModuleNames.push('module' + index) -%>
+    <% } else { -%>
+      <% moduleNames.push('module' + index) -%>
+    <% } -%>
   <% }) -%>
 <% } -%>
 
-const modules = [
+export const statics = [
+<% staticModuleNames.forEach((moduleName, index) => { -%>
+  <%= moduleName %>,
+<% }) -%>
+];
+export const commons = [
 <% moduleNames.forEach((moduleName, index) => { -%>
   <%= moduleName %>,
 <% }) -%>
 ];
 
-export default modules;
+

--- a/packages/miniapp-runtime/src/app/runClientApp.tsx
+++ b/packages/miniapp-runtime/src/app/runClientApp.tsx
@@ -17,14 +17,14 @@ export default async function runClientApp(options: RunClientAppOptions) {
     appData: null,
   };
   const runtime = new Runtime(appContext);
-  await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  await Promise.all(runtimeModules.statics?.map(m => runtime.loadModule(m)).filter(Boolean));
   const appData = await getAppData(app);
   const { miniappManifest } = app;
 
   setHistory(miniappManifest.routes);
   runtime.setAppContext({ ...appContext, appData });
   // TODO: to be tested
-  await Promise.all(runtimeModules?.commons.map(m => runtime.loadModule(m)).filter(Boolean));
+  await Promise.all(runtimeModules.commons?.map(m => runtime.loadModule(m)).filter(Boolean));
   render(runtime);
   // TODO: transform routes to pages in miniappManifest
   createMiniApp(miniappManifest);

--- a/packages/miniapp-runtime/src/app/runClientApp.tsx
+++ b/packages/miniapp-runtime/src/app/runClientApp.tsx
@@ -17,14 +17,18 @@ export default async function runClientApp(options: RunClientAppOptions) {
     appData: null,
   };
   const runtime = new Runtime(appContext);
-  await Promise.all(runtimeModules.statics?.map(m => runtime.loadModule(m)).filter(Boolean));
+  if (runtimeModules.statics) {
+    await Promise.all(runtimeModules.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  }
   const appData = await getAppData(app);
   const { miniappManifest } = app;
 
   setHistory(miniappManifest.routes);
   runtime.setAppContext({ ...appContext, appData });
   // TODO: to be tested
-  await Promise.all(runtimeModules.commons?.map(m => runtime.loadModule(m)).filter(Boolean));
+  if (runtimeModules.commons) {
+    await Promise.all(runtimeModules.commons.map(m => runtime.loadModule(m)).filter(Boolean));
+  }
   render(runtime);
   // TODO: transform routes to pages in miniappManifest
   createMiniApp(miniappManifest);

--- a/packages/miniapp-runtime/src/app/runClientApp.tsx
+++ b/packages/miniapp-runtime/src/app/runClientApp.tsx
@@ -10,19 +10,21 @@ import { setHistory } from './history.js';
 
 export default async function runClientApp(options: RunClientAppOptions) {
   const { app, runtimeModules } = options;
-  const appData = await getAppData(app);
-  const { miniappManifest } = app;
   const appConfig = getAppConfig(app);
-  setHistory(miniappManifest.routes);
   const appContext: AppContext = {
     appExport: app,
     appConfig,
-    appData,
+    appData: null,
   };
   const runtime = new Runtime(appContext);
+  await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  const appData = await getAppData(app);
+  const { miniappManifest } = app;
 
+  setHistory(miniappManifest.routes);
+  runtime.setAppContext({ ...appContext, appData });
   // TODO: to be tested
-  await Promise.all(runtimeModules.map(m => runtime.loadModule(m)).filter(Boolean));
+  await Promise.all(runtimeModules?.commons.map(m => runtime.loadModule(m)).filter(Boolean));
   render(runtime);
   // TODO: transform routes to pages in miniappManifest
   createMiniApp(miniappManifest);

--- a/packages/plugin-request/src/index.ts
+++ b/packages/plugin-request/src/index.ts
@@ -25,6 +25,7 @@ const plugin: Plugin<PluginRequestOptions | void> = () => ({
     });
   },
   runtime: `${PLUGIN_NAME}/esm/runtime`,
+  staticRuntime: true,
 });
 
 export type {

--- a/packages/runtime/src/routesConfig.ts
+++ b/packages/runtime/src/routesConfig.ts
@@ -30,7 +30,6 @@ export function getTitle(matches: RouteMatch[], routesConfig: RoutesConfig): str
  */
 function getMergedValue(key: string, matches: RouteMatch[], routesConfig: RoutesConfig) {
   let result;
-
   for (let match of matches) {
     const routeId = match.route.id;
     const data = routesConfig[routeId];
@@ -57,7 +56,6 @@ export async function updateRoutesConfig(matches: RouteMatch[], routesConfig: Ro
   if (title) {
     document.title = title;
   }
-
   const meta = getMeta(matches, routesConfig) || [];
   const links = getLinks(matches, routesConfig) || [];
   const scripts = getScripts(matches, routesConfig) || [];

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -71,7 +71,9 @@ export default async function runClientApp(options: RunClientAppOptions) {
   runtime.setAppRouter(DefaultAppRouter);
   // Load static module before getAppData,
   // so we can call request in in getAppData which provide by `plugin-request`.
-  await Promise.all(runtimeModules.statics?.map(m => runtime.loadModule(m)).filter(Boolean));
+  if (runtimeModules.statics) {
+    await Promise.all(runtimeModules.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  }
 
   if (!appData) {
     appData = await getAppData(app, requestContext);
@@ -97,8 +99,10 @@ export default async function runClientApp(options: RunClientAppOptions) {
     });
   }
   // Reset app context after app context is updated.
-  runtime.setAppContext({ ...appContext, matches, routeModules, routesData, routesConfig });
-  await Promise.all(runtimeModules.commons?.map(m => runtime.loadModule(m)).filter(Boolean));
+  runtime.setAppContext({ ...appContext, matches, routeModules, routesData, routesConfig, appData });
+  if (runtimeModules.commons) {
+    await Promise.all(runtimeModules.commons.map(m => runtime.loadModule(m)).filter(Boolean));
+  }
 
   render({ runtime, history });
 }

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -50,15 +50,32 @@ export default async function runClientApp(options: RunClientAppOptions) {
   } = windowContext;
 
   const requestContext = getRequestContext(window.location);
-
-  if (!appData) {
-    appData = await getAppData(app, requestContext);
-  }
-
   const appConfig = getAppConfig(app);
   const history = createHistory(appConfig, { memoryRouter, routePath });
   // Set history for import it from ice.
   setHistory(history);
+
+  const appContext: AppContext = {
+    appExport: app,
+    routes,
+    appConfig,
+    appData,
+    routesData,
+    routesConfig,
+    assetsManifest,
+    basename,
+    routePath,
+  };
+
+  const runtime = new Runtime(appContext);
+  runtime.setAppRouter(DefaultAppRouter);
+  // Load static module before getAppData,
+  // so we can call request in in getAppData which provide by `plugin-request`.
+  await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+
+  if (!appData) {
+    appData = await getAppData(app, requestContext);
+  }
 
   const matches = matchRoutes(
     routes,
@@ -74,30 +91,14 @@ export default async function runClientApp(options: RunClientAppOptions) {
     routesConfig = getRoutesConfig(matches, routesData, routeModules);
   }
 
-  const appContext: AppContext = {
-    appExport: app,
-    routes,
-    appConfig,
-    appData,
-    routesData,
-    routesConfig,
-    assetsManifest,
-    matches,
-    routeModules,
-    basename,
-    routePath,
-  };
-
-  const runtime = new Runtime(appContext);
-  runtime.setAppRouter(DefaultAppRouter);
-
   if (hydrate && !downgrade) {
     runtime.setRender((container, element) => {
       ReactDOM.hydrateRoot(container, element);
     });
   }
-
-  await Promise.all(runtimeModules.map(m => runtime.loadModule(m)).filter(Boolean));
+  // Reset app context after app context is updated.
+  runtime.setAppContext({ ...appContext, matches, routeModules, routesData, routesConfig });
+  await Promise.all(runtimeModules?.commons.map(m => runtime.loadModule(m)).filter(Boolean));
 
   render({ runtime, history });
 }

--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -71,7 +71,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
   runtime.setAppRouter(DefaultAppRouter);
   // Load static module before getAppData,
   // so we can call request in in getAppData which provide by `plugin-request`.
-  await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  await Promise.all(runtimeModules.statics?.map(m => runtime.loadModule(m)).filter(Boolean));
 
   if (!appData) {
     appData = await getAppData(app, requestContext);
@@ -98,7 +98,7 @@ export default async function runClientApp(options: RunClientAppOptions) {
   }
   // Reset app context after app context is updated.
   runtime.setAppContext({ ...appContext, matches, routeModules, routesData, routesConfig });
-  await Promise.all(runtimeModules?.commons.map(m => runtime.loadModule(m)).filter(Boolean));
+  await Promise.all(runtimeModules.commons?.map(m => runtime.loadModule(m)).filter(Boolean));
 
   render({ runtime, history });
 }

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -5,15 +5,12 @@ import { Action, parsePath } from 'history';
 import type { Location } from 'history';
 import type {
   AppContext, RouteItem, ServerContext,
-  AppData,
-  AppExport, RuntimePlugin, CommonJsRuntime, AssetsManifest,
+  AppExport, AssetsManifest,
   RouteMatch,
-  RequestContext,
-  AppConfig,
   GetConfig,
-  RouteModules,
   RenderMode,
   DocumentComponent,
+  RuntimeModules,
 } from '@ice/types';
 import Runtime from './runtime.js';
 import App from './App.js';
@@ -34,7 +31,7 @@ interface RenderOptions {
   app: AppExport;
   assetsManifest: AssetsManifest;
   routes: RouteItem[];
-  runtimeModules: (RuntimePlugin | CommonJsRuntime)[];
+  runtimeModules: RuntimeModules;
   Document: DocumentComponent;
   documentOnly?: boolean;
   renderMode?: RenderMode;
@@ -141,19 +138,48 @@ function pipeToResponse(res: ServerResponse, pipe: NodeWritablePiper) {
 
 async function doRender(serverContext: ServerContext, renderOptions: RenderOptions): Promise<RenderResult> {
   const { req } = serverContext;
-  const { routes, documentOnly, app, basename, serverOnlyBasename, disableFallback } = renderOptions;
+  const {
+    app,
+    basename,
+    serverOnlyBasename,
+    routes,
+    documentOnly,
+    disableFallback,
+    assetsManifest,
+    runtimeModules,
+    renderMode,
+    Document,
+  } = renderOptions;
 
   const location = getLocation(req.url);
 
   const requestContext = getRequestContext(location, serverContext);
+  const appConfig = getAppConfig(app);
+  let appData: any;
+  const appContext: AppContext = {
+    appExport: app,
+    routes,
+    appConfig,
+    appData,
+    routesData: null,
+    routesConfig: null,
+    assetsManifest,
+    basename,
+    matches: [],
+  };
+  const runtime = new Runtime(appContext);
+  runtime.setAppRouter(DefaultAppRouter);
+  // Load static module before getAppData.
+  // await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
 
-  let appData;
   // don't need to execute getAppData in CSR
   if (!documentOnly) {
-    appData = await getAppData(app, requestContext);
+    try {
+      appData = await getAppData(app, requestContext);
+    } catch (err) {
+      console.error('Error: get app data error when SSR.', err);
+    }
   }
-
-  const appConfig = getAppConfig(app);
   // HashRouter loads route modules by the CSR.
   if (appConfig?.router?.type === 'hash') {
     return renderDocument({ matches: [], renderOptions });
@@ -169,21 +195,17 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
   if (documentOnly) {
     return renderDocument({ matches, routePath, renderOptions });
   }
-
-  const routeModules = await loadRouteModules(matches.map(({ route: { id, load } }) => ({ id, load })));
-
   try {
+    const routeModules = await loadRouteModules(matches.map(({ route: { id, load } }) => ({ id, load })));
+    const routesData = await loadRoutesData(matches, requestContext, routeModules, renderMode);
+    const routesConfig = getRoutesConfig(matches, routesData, routeModules);
+    runtime.setAppContext({ ...appContext, routeModules, routesData, routesConfig, routePath, matches });
+    await Promise.all(runtimeModules?.commons.map(m => runtime.loadModule(m)).filter(Boolean));
     return await renderServerEntry({
-      appExport: app,
-      requestContext,
-      renderOptions,
+      runtime,
       matches,
       location,
-      appConfig,
-      appData,
-      routeModules,
-      basename: serverOnlyBasename || basename,
-      routePath,
+      renderOptions,
     });
   } catch (err) {
     if (disableFallback) {
@@ -202,17 +224,11 @@ function render404(): RenderResult {
   };
 }
 
-interface renderServerEntry {
-  appExport: AppExport;
-  requestContext: RequestContext;
-  renderOptions: RenderOptions;
+interface RenderServerEntry {
+  runtime: Runtime;
   matches: RouteMatch[];
   location: Location;
-  appConfig: AppConfig;
-  appData: AppData;
-  routeModules: RouteModules;
-  routePath?: string;
-  basename?: string;
+  renderOptions: RenderOptions;
 }
 
 /**
@@ -220,47 +236,15 @@ interface renderServerEntry {
  */
 async function renderServerEntry(
   {
-    appExport,
-    requestContext,
+    runtime,
     matches,
     location,
-    appConfig,
-    appData,
     renderOptions,
-    routeModules,
-    basename,
-    routePath,
-  }: renderServerEntry,
+  }: RenderServerEntry,
 ): Promise<RenderResult> {
-  const {
-    assetsManifest,
-    runtimeModules,
-    routes,
-    renderMode,
-    Document,
-  } = renderOptions;
-
-  const routesData = await loadRoutesData(matches, requestContext, routeModules, renderMode);
-  const routesConfig = getRoutesConfig(matches, routesData, routeModules);
-
-  const appContext: AppContext = {
-    appExport,
-    assetsManifest,
-    appConfig,
-    appData,
-    routesData,
-    routesConfig,
-    matches,
-    routes,
-    routeModules,
-    basename,
-    routePath,
-  };
-
-  const runtime = new Runtime(appContext);
-  runtime.setAppRouter(DefaultAppRouter);
-  await Promise.all(runtimeModules.map(m => runtime.loadModule(m)).filter(Boolean));
-
+  const { Document } = renderOptions;
+  const appContext = runtime.getAppContext();
+  const { appData, routePath } = appContext;
   const staticNavigator = createStaticNavigator();
   const AppProvider = runtime.composeAppProvider() || React.Fragment;
   const RouteWrappers = runtime.getWrappers();

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -170,8 +170,9 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
   const runtime = new Runtime(appContext);
   runtime.setAppRouter(DefaultAppRouter);
   // Load static module before getAppData.
-  await Promise.all(runtimeModules.statics?.map(m => runtime.loadModule(m)).filter(Boolean));
-
+  if (runtimeModules.statics) {
+    await Promise.all(runtimeModules.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  }
   // don't need to execute getAppData in CSR
   if (!documentOnly) {
     try {
@@ -199,8 +200,10 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
     const routeModules = await loadRouteModules(matches.map(({ route: { id, load } }) => ({ id, load })));
     const routesData = await loadRoutesData(matches, requestContext, routeModules, renderMode);
     const routesConfig = getRoutesConfig(matches, routesData, routeModules);
-    runtime.setAppContext({ ...appContext, routeModules, routesData, routesConfig, routePath, matches });
-    await Promise.all(runtimeModules.commons?.map(m => runtime.loadModule(m)).filter(Boolean));
+    runtime.setAppContext({ ...appContext, routeModules, routesData, routesConfig, routePath, matches, appData });
+    if (runtimeModules.commons) {
+      await Promise.all(runtimeModules.commons.map(m => runtime.loadModule(m)).filter(Boolean));
+    }
     return await renderServerEntry({
       runtime,
       matches,

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -170,7 +170,7 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
   const runtime = new Runtime(appContext);
   runtime.setAppRouter(DefaultAppRouter);
   // Load static module before getAppData.
-  await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  await Promise.all(runtimeModules.statics?.map(m => runtime.loadModule(m)).filter(Boolean));
 
   // don't need to execute getAppData in CSR
   if (!documentOnly) {
@@ -200,7 +200,7 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
     const routesData = await loadRoutesData(matches, requestContext, routeModules, renderMode);
     const routesConfig = getRoutesConfig(matches, routesData, routeModules);
     runtime.setAppContext({ ...appContext, routeModules, routesData, routesConfig, routePath, matches });
-    await Promise.all(runtimeModules?.commons.map(m => runtime.loadModule(m)).filter(Boolean));
+    await Promise.all(runtimeModules.commons?.map(m => runtime.loadModule(m)).filter(Boolean));
     return await renderServerEntry({
       runtime,
       matches,

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -148,7 +148,6 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
     assetsManifest,
     runtimeModules,
     renderMode,
-    Document,
   } = renderOptions;
 
   const location = getLocation(req.url);

--- a/packages/runtime/src/runServerApp.tsx
+++ b/packages/runtime/src/runServerApp.tsx
@@ -170,7 +170,7 @@ async function doRender(serverContext: ServerContext, renderOptions: RenderOptio
   const runtime = new Runtime(appContext);
   runtime.setAppRouter(DefaultAppRouter);
   // Load static module before getAppData.
-  // await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
+  await Promise.all(runtimeModules?.statics.map(m => runtime.loadModule(m)).filter(Boolean));
 
   // don't need to execute getAppData in CSR
   if (!documentOnly) {

--- a/packages/runtime/src/runtime.tsx
+++ b/packages/runtime/src/runtime.tsx
@@ -41,6 +41,10 @@ class Runtime {
 
   public getAppContext = () => this.appContext;
 
+  public setAppContext = (appContext: AppContext) => {
+    this.appContext = appContext;
+  };
+
   public getRender = () => {
     return this.render;
   };

--- a/packages/runtime/tests/runClientApp.test.tsx
+++ b/packages/runtime/tests/runClientApp.test.tsx
@@ -96,7 +96,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: false,
     });
     expect(domstring).toBe('<div>home</div>');
@@ -107,7 +107,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: false,
     });
     process.env.ICE_CORE_ROUTER = 'true';
@@ -118,7 +118,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: { common: [serverRuntime, wrapperRuntime] },
+      runtimeModules: { commons: [serverRuntime, wrapperRuntime] },
       hydrate: true,
     });
     expect(domstring).toBe('<div><div>home</div></div>');
@@ -128,7 +128,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: { common: [serverRuntime, providerRuntmie] },
+      runtimeModules: { commons: [serverRuntime, providerRuntmie] },
       hydrate: true,
     });
     expect(domstring).toBe('<div><div><div>home</div></div></div>');
@@ -138,7 +138,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: [],
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: false,
     });
   });
@@ -166,7 +166,7 @@ describe('run client app', () => {
         },
       },
       routes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: true,
     });
 
@@ -177,7 +177,7 @@ describe('run client app', () => {
         },
       },
       routes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: true,
     });
   });
@@ -205,7 +205,7 @@ describe('run client app', () => {
       app: {
       },
       routes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: true,
       memoryRouter: true,
     });
@@ -223,7 +223,7 @@ describe('run client app', () => {
         },
       },
       routes: basicRoutes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: true,
     });
     expect(domstring).toBe('<div>home</div>');
@@ -239,7 +239,7 @@ describe('run client app', () => {
         },
       },
       routes: basicRoutes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: false,
     });
     expect(domstring).toBe('<div>home<!-- -->-getAppData</div>');
@@ -265,7 +265,7 @@ describe('run client app', () => {
         },
       },
       routes: basicRoutes,
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: false,
     });
     expect(executed).toBe(false);
@@ -300,7 +300,7 @@ describe('run client app', () => {
           getData: async () => ({ data: 'test' }),
         }),
       }],
-      runtimeModules: { common: [serverRuntime] },
+      runtimeModules: { commons: [serverRuntime] },
       hydrate: false,
     });
     expect(domstring).toBe('<div>home<!-- -->test<!-- -->home</div>');

--- a/packages/runtime/tests/runClientApp.test.tsx
+++ b/packages/runtime/tests/runClientApp.test.tsx
@@ -96,7 +96,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: false,
     });
     expect(domstring).toBe('<div>home</div>');
@@ -107,7 +107,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: false,
     });
     process.env.ICE_CORE_ROUTER = 'true';
@@ -118,7 +118,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: [serverRuntime, wrapperRuntime],
+      runtimeModules: { common: [serverRuntime, wrapperRuntime] },
       hydrate: true,
     });
     expect(domstring).toBe('<div><div>home</div></div>');
@@ -128,7 +128,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: basicRoutes,
-      runtimeModules: [serverRuntime, providerRuntmie],
+      runtimeModules: { common: [serverRuntime, providerRuntmie] },
       hydrate: true,
     });
     expect(domstring).toBe('<div><div><div>home</div></div></div>');
@@ -138,7 +138,7 @@ describe('run client app', () => {
     await runClientApp({
       app: {},
       routes: [],
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: false,
     });
   });
@@ -166,7 +166,7 @@ describe('run client app', () => {
         },
       },
       routes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: true,
     });
 
@@ -177,7 +177,7 @@ describe('run client app', () => {
         },
       },
       routes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: true,
     });
   });
@@ -205,7 +205,7 @@ describe('run client app', () => {
       app: {
       },
       routes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: true,
       memoryRouter: true,
     });
@@ -223,7 +223,7 @@ describe('run client app', () => {
         },
       },
       routes: basicRoutes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: true,
     });
     expect(domstring).toBe('<div>home</div>');
@@ -239,7 +239,7 @@ describe('run client app', () => {
         },
       },
       routes: basicRoutes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: false,
     });
     expect(domstring).toBe('<div>home<!-- -->-getAppData</div>');
@@ -265,7 +265,7 @@ describe('run client app', () => {
         },
       },
       routes: basicRoutes,
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: false,
     });
     expect(executed).toBe(false);
@@ -300,7 +300,7 @@ describe('run client app', () => {
           getData: async () => ({ data: 'test' }),
         }),
       }],
-      runtimeModules: [serverRuntime],
+      runtimeModules: { common: [serverRuntime] },
       hydrate: false,
     });
     expect(domstring).toBe('<div>home<!-- -->test<!-- -->home</div>');

--- a/packages/runtime/tests/runClientApp.test.tsx
+++ b/packages/runtime/tests/runClientApp.test.tsx
@@ -52,6 +52,12 @@ describe('run client app', () => {
     });
   };
 
+  let staticMsg = '';
+
+  const staticRuntime = async () => {
+    staticMsg = 'static';
+  };
+
   const wrapperRuntime = async ({ addWrapper }) => {
     const RouteWrapper = ({ children }) => {
       return <div>{children}</div>;
@@ -86,6 +92,20 @@ describe('run client app', () => {
       }),
     },
   ];
+
+  it('run with static runtime', async () => {
+    await runClientApp({
+      app: {
+        getAppData: async () => {
+          return { msg: staticMsg };
+        },
+      },
+      routes: basicRoutes,
+      runtimeModules: { commons: [serverRuntime], statics: [staticRuntime] },
+      hydrate: false,
+    });
+    expect(domstring).toBe('<div>home<!-- -->static</div>');
+  });
 
   it('run client basic', async () => {
     windowSpy.mockImplementation(() => ({

--- a/packages/runtime/tests/runServerApp.test.tsx
+++ b/packages/runtime/tests/runServerApp.test.tsx
@@ -57,7 +57,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: [],
+      runtimeModules: { common: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',
@@ -77,7 +77,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: [],
+      runtimeModules: { common: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',
@@ -96,7 +96,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: [],
+      runtimeModules: { common: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',
@@ -116,7 +116,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: [],
+      runtimeModules: { common: [] },
       routes: basicRoutes,
       Document,
     });
@@ -139,7 +139,7 @@ describe('run server app', () => {
         },
       },
       assetsManifest,
-      runtimeModules: [],
+      runtimeModules: { common: [] },
       routes: basicRoutes,
       Document,
     });
@@ -158,7 +158,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: [],
+      runtimeModules: { common: [] },
       routes: [{
         id: 'home',
         path: 'home',
@@ -197,7 +197,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: [],
+      runtimeModules: { common: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',

--- a/packages/runtime/tests/runServerApp.test.tsx
+++ b/packages/runtime/tests/runServerApp.test.tsx
@@ -57,7 +57,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: { common: [] },
+      runtimeModules: { commons: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',
@@ -77,7 +77,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: { common: [] },
+      runtimeModules: { commons: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',
@@ -96,7 +96,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: { common: [] },
+      runtimeModules: { commons: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',
@@ -116,7 +116,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: { common: [] },
+      runtimeModules: { commons: [] },
       routes: basicRoutes,
       Document,
     });
@@ -139,7 +139,7 @@ describe('run server app', () => {
         },
       },
       assetsManifest,
-      runtimeModules: { common: [] },
+      runtimeModules: { commons: [] },
       routes: basicRoutes,
       Document,
     });
@@ -158,7 +158,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: { common: [] },
+      runtimeModules: { commons: [] },
       routes: [{
         id: 'home',
         path: 'home',
@@ -197,7 +197,7 @@ describe('run server app', () => {
     }, {
       app: {},
       assetsManifest,
-      runtimeModules: { common: [] },
+      runtimeModules: { commons: [] },
       routes: basicRoutes,
       Document,
       renderMode: 'SSR',

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -182,7 +182,10 @@ export interface CommonJsRuntime {
   default: RuntimePlugin;
 }
 
-export type RuntimeModules = (RuntimePlugin | CommonJsRuntime)[];
+export interface RuntimeModules {
+  statics?: (RuntimePlugin | CommonJsRuntime)[];
+  commons?: (RuntimePlugin | CommonJsRuntime)[];
+}
 
 export interface AppRouterProps {
   action: Action;


### PR DESCRIPTION
`statc runtime` 说明：
对于一些支持在 src/app 入口就可以使用的 API，如 request 的运行时能力，需要在应用数据 / 路由数据加载获取前就需要加载，否则在 getAppData 中将无法享受到统一的配置能力

Close #604 #605 