### PR TITLE
fix: add assets manifest only in js file

### DIFF
--- a/packages/webpack-config/src/webpackPlugins/AssetsManifestPlugin.ts
+++ b/packages/webpack-config/src/webpackPlugins/AssetsManifestPlugin.ts
@@ -48,7 +48,8 @@ export default class AssetsManifestPlugin {
       const entryName = entrypoint.name;
       const mainFiles = filterAssets(entrypoint);
       entries[entryName] = mainFiles;
-      entryFiles.push(mainFiles[0]);
+      const jsMainFiles = mainFiles.filter((file) => file.endsWith('.js'));
+      entryFiles.push(jsMainFiles[0]);
       const chunks = entrypoint?.getChildren();
       chunks.forEach((chunk) => {
         const chunkName = chunk.name;


### PR DESCRIPTION
Fix error when assets manifest add to css file.

![image](https://user-images.githubusercontent.com/44047106/197956199-668f26f2-9e6b-4383-b6d3-9d5999fd7c17.png)
