### PR TITLE
fix: duplicate assets in document output

### DIFF
--- a/packages/ice/templates/core/entry.client.tsx.ejs
+++ b/packages/ice/templates/core/entry.client.tsx.ejs
@@ -10,7 +10,9 @@ const getRouterBasename = () => {
   const appConfig = getAppConfig(app);
   return appConfig?.router?.basename ?? '<%- basename %>' ?? '';
 }
-
+// Add react fragment for split chunks of app.
+// Otherwise chunk of route component will pack @ice/jsx-runtime and depend on framework bundle.
+const App = <></>;
 runClientApp({
   app,
   runtimeModules: {

--- a/packages/runtime/src/Document.tsx
+++ b/packages/runtime/src/Document.tsx
@@ -70,11 +70,19 @@ export function Scripts(props: React.ScriptHTMLAttributes<HTMLScriptElement>) {
   const pageAssets = getPageAssets(matches, assetsManifest);
   const entryAssets = getEntryAssets(assetsManifest);
   // Page assets need to be load before entry assets, so when call dynamic import won't cause duplicate js chunk loaded.
-  const scripts = pageAssets.concat(entryAssets).filter(path => path.indexOf('.js') > -1);
+  let scripts = pageAssets.concat(entryAssets).filter(path => path.indexOf('.js') > -1);
 
   if (assetsManifest.dataLoader) {
     scripts.unshift(`${assetsManifest.publicPath}${assetsManifest.dataLoader}`);
   }
+
+  // Unique scripts for duplicate chuns.
+  const jsSet = {};
+  scripts = scripts.filter((script) => {
+    if (jsSet[script]) return false;
+    jsSet[script] = true;
+    return true;
+  });
 
   const matchedIds = matches.map(match => match.route.id);
   const routePath = getCurrentRoutePath(matches);

--- a/packages/runtime/src/Document.tsx
+++ b/packages/runtime/src/Document.tsx
@@ -76,7 +76,7 @@ export function Scripts(props: React.ScriptHTMLAttributes<HTMLScriptElement>) {
     scripts.unshift(`${assetsManifest.publicPath}${assetsManifest.dataLoader}`);
   }
 
-  // Unique scripts for duplicate chuns.
+  // Unique scripts for duplicate chunks.
   const jsSet = {};
   scripts = scripts.filter((script) => {
     if (jsSet[script]) return false;

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -48,7 +48,7 @@ function getEntry(rootDir: string, runtimeTmpDir: string) {
   })[0];
   if (!entryFile) {
     // use generated file in template directory
-    entryFile = path.join(rootDir, runtimeTmpDir, 'entry.client.ts');
+    entryFile = path.join(rootDir, runtimeTmpDir, 'entry.client.tsx');
   }
 
   // const dataLoaderFile = path.join(rootDir, '.ice/data-loader.ts');

--- a/tests/integration/basic-project.test.ts
+++ b/tests/integration/basic-project.test.ts
@@ -33,7 +33,8 @@ describe(`build ${example}`, () => {
     expect(bundleContent.includes('__IS_NODE__')).toBe(false);
     expect(fs.existsSync(path.join(__dirname, `../../examples/${example}/build/favicon.ico`))).toBe(true);
     expect(fs.existsSync(path.join(__dirname, `../../examples/${example}/build/js/data-loader.js`))).toBe(true);
-
+    const jsonContent = fs.readFileSync(path.join(__dirname, `../../examples/${example}/build/assets-manifest.json`), 'utf-8');
+    expect(JSON.parse(jsonContent).pages.about.includes('js/framework.js')).toBeFalsy();
     const dataLoaderPath = path.join(__dirname, `../../examples/${example}/build/js/data-loader.js`);
     // should not contain react
     const dataLoaderContent = fs.readFileSync(dataLoaderPath, 'utf-8');


### PR DESCRIPTION
Fix #630

- 模版入口中增加 react 组件写法，确保 jsx-runtime 在入口已被依赖，原因是 entry 不依赖任何组件的情况下 @ice/jsx-runtime 将会在路由组件 chunk 中打包，导致额外依赖 framework
- 增加重复脚本输出的过滤，确保异常 case 的重复 chunk