### PR TITLE
refactor: hydrate error

### DIFF
--- a/packages/runtime/src/runClientApp.tsx
+++ b/packages/runtime/src/runClientApp.tsx
@@ -98,7 +98,11 @@ export default async function runClientApp(options: RunClientAppOptions) {
 
   if (hydrate && !downgrade && !documentOnly) {
     runtime.setRender((container, element) => {
-      ReactDOM.hydrateRoot(container, element);
+      ReactDOM.hydrateRoot(container, element, {
+        onRecoverableError: (error) => {
+          console.error(error);
+        },
+      });
     });
   }
   // Reset app context after app context is updated.


### PR DESCRIPTION
### 现状

当出现 Hydrate 错误时，react 会打印如下日志

![image](https://user-images.githubusercontent.com/1303018/198962534-319a9007-40a7-4c15-a215-a2bb3683405f.png)

即使在 production 模式，这些日志也会存在（虽然已经降级到 CSR，页面渲染正确）

![image](https://user-images.githubusercontent.com/1303018/198962685-8f9fcc22-c1c2-41f6-a65e-46f3bbdbbf40.png)

导致 JSTracker 等监控软件捕获到大量 Hydrate 错误

这是因为 Hydrate 默认使用了 reportError 打印日志

https://github.com/facebook/react/blob/8e2bde6f2751aa6335f3cef488c05c3ea08e074a/packages/react-dom/src/client/ReactDOMRoot.js#L84

而 reportError 会被 `window.onerror` 捕获

### 解决方案

通过 `onRecoverableError` 将 `reportError` 转为 `console.error`




