### PR TITLE
feat: read browsers config by postcss-preset-env

### DIFF
--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -21,7 +21,6 @@
     "@swc/core": "1.3.3",
     "@ice/bundles": "^0.1.0",
     "@rollup/pluginutils": "^4.2.0",
-    "browserslist": "^4.19.3",
     "consola": "^2.15.3",
     "fast-glob": "^3.2.11"
   },

--- a/packages/webpack-config/src/config/css.ts
+++ b/packages/webpack-config/src/config/css.ts
@@ -10,13 +10,12 @@ import type { ModifyWebpackConfig } from '../types.js';
 type CSSRuleConfig = [string, string?, Record<string, any>?];
 interface Options {
   publicPath: string;
-  browsers: string[];
 }
 
 const require = createRequire(import.meta.url);
 
 function configCSSRule(config: CSSRuleConfig, options: Options) {
-  const { publicPath, browsers } = options;
+  const { publicPath } = options;
   const [style, loader, loaderOptions] = config;
   const cssLoaderOpts = {
     sourceMap: true,
@@ -57,7 +56,6 @@ function configCSSRule(config: CSSRuleConfig, options: Options) {
           features: {
             'custom-properties': false,
           },
-          browsers,
         }],
         ['@ice/bundles/compiled/postcss-plugin-rpx2vw'],
       ],
@@ -94,7 +92,7 @@ function configCSSRule(config: CSSRuleConfig, options: Options) {
 }
 
 const css: ModifyWebpackConfig<Configuration, typeof webpack> = (config, ctx) => {
-  const { supportedBrowsers, publicPath, hashKey, cssFilename, cssChunkFilename } = ctx;
+  const { publicPath, hashKey, cssFilename, cssChunkFilename } = ctx;
   const cssOutputFolder = 'css';
   config.module.rules.push(...([
     ['css'],
@@ -105,7 +103,7 @@ const css: ModifyWebpackConfig<Configuration, typeof webpack> = (config, ctx) =>
     ['scss', require.resolve('@ice/bundles/compiled/sass-loader'), {
       implementation: sass,
     }],
-  ] as CSSRuleConfig[]).map((config) => configCSSRule(config, { publicPath, browsers: supportedBrowsers })));
+  ] as CSSRuleConfig[]).map((config) => configCSSRule(config, { publicPath })));
   config.plugins.push(
     new MiniCssExtractPlugin({
       filename: cssFilename || `${cssOutputFolder}/${hashKey ? `[name]-[${hashKey}].css` : '[name].css'}`,

--- a/packages/webpack-config/src/index.ts
+++ b/packages/webpack-config/src/index.ts
@@ -13,7 +13,6 @@ import ESlintPlugin from '@ice/bundles/compiled/eslint-webpack-plugin/index.js';
 import CopyPlugin from '@ice/bundles/compiled/copy-webpack-plugin/index.js';
 import type { NormalModule, Compiler, Configuration } from 'webpack';
 import type webpack from 'webpack';
-import browserslist from 'browserslist';
 import type { Config, ModifyWebpackConfig } from './types.js';
 import configAssets from './config/assets.js';
 import configCss from './config/css.js';
@@ -98,7 +97,6 @@ const getWebpackConfig: GetWebpackConfig = ({ rootDir, config, webpack, runtimeT
   } = config;
   const absoluteOutputDir = path.isAbsolute(outputDir) ? outputDir : path.join(rootDir, outputDir);
   const dev = mode !== 'production';
-  const supportedBrowsers = getSupportedBrowsers(rootDir, dev);
   const hashKey = hash === true ? 'hash:8' : (hash || '');
   // formate alias
   const aliasWithRoot = {};
@@ -397,7 +395,6 @@ const getWebpackConfig: GetWebpackConfig = ({ rootDir, config, webpack, runtimeT
   // pipe webpack by built-in functions and custom functions
   const ctx = {
     ...config,
-    supportedBrowsers,
     hashKey,
     webpack,
   };
@@ -415,23 +412,6 @@ function getDevtoolValue(sourceMap: Config['sourceMap']) {
   }
 
   return 'source-map';
-}
-
-function getSupportedBrowsers(
-  dir: string,
-  isDevelopment: boolean,
-): string[] | undefined {
-  let browsers: any;
-  try {
-    browsers = browserslist.loadConfig({
-      path: dir,
-      env: isDevelopment ? 'development' : 'production',
-    });
-  } catch {
-    consola.debug('[browsers]', 'fail to load config of browsers');
-  }
-
-  return browsers;
 }
 
 export {

--- a/packages/webpack-config/src/types.ts
+++ b/packages/webpack-config/src/types.ts
@@ -28,7 +28,6 @@ interface PredefinedOptions {
 export type MinimizerOptions<T> = PredefinedOptions & InferDefaultType<T>;
 
 interface ConfigurationCtx<T = typeof webpack> extends Config {
-  supportedBrowsers: string[];
   hashKey: string;
   webpack: T;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1142,7 +1142,6 @@ importers:
       '@ice/swc-plugin-remove-export': 0.1.1
       '@rollup/pluginutils': ^4.2.0
       '@swc/core': 1.3.3
-      browserslist: ^4.19.3
       consola: ^2.15.3
       esbuild: ^0.14.51
       fast-glob: ^3.2.11
@@ -1155,7 +1154,6 @@ importers:
       '@ice/swc-plugin-remove-export': 0.1.1
       '@rollup/pluginutils': 4.2.1
       '@swc/core': 1.3.3
-      browserslist: 4.21.4
       consola: 2.15.3
       fast-glob: 3.2.12
     devDependencies:


### PR DESCRIPTION
#634 

1. swc 和 postcss-preset-env 默认会读取项目的 .browserslistrc 和 package.json 中的 browserslist 配置作为目标浏览器，框架默认就不处理 browserslist 的配置，都交给对应的 compiler 做处理好了。故此 PR 去掉

2. 推荐主流浏览器版本，默认写在模板的 .browserslist 