### PR TITLE
refactor: data loader

### DIFF
--- a/examples/with-data-loader/src/pages/home.tsx
+++ b/examples/with-data-loader/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { useData } from 'ice';
+import { useData, defineDataLoader } from 'ice';
 import styles from './index.module.css';
 
 export default function Home() {
@@ -18,9 +18,9 @@ export function getConfig() {
   };
 }
 
-export async function getData() {
+export const dataLoader = defineDataLoader(async () => {
   const result = await fetch('https://api.github.com/repos/ice-lab/ice-next');
   const data = await result.json();
 
   return data;
-}
+});

--- a/packages/ice/templates/exports/data-loader.ts.ejs
+++ b/packages/ice/templates/exports/data-loader.ts.ejs
@@ -1,5 +1,5 @@
 import { dataLoader } from '@ice/runtime';
-<% if(hasExportAppData) {-%>import * as app from '@/app';<% } -%>
+import * as app from '@/app';
 <% if(dataLoaderImport.imports) {-%><%-dataLoaderImport.imports%><% } -%>
 <% const staticModuleNames = []; -%>
 <% if (runtimeModules.length) { -%>
@@ -36,6 +36,5 @@ dataLoader.init(loaders, {
   fetcher,
   runtimeModules: staticRuntimeModules,
   appExport: app,
-  needLoadData: true,
   <% if(dataLoaderImport.imports) {-%>dataLoaderFetcher<% } -%>
 });

--- a/packages/runtime/src/AppData.tsx
+++ b/packages/runtime/src/AppData.tsx
@@ -17,10 +17,10 @@ const AppDataProvider = Context.Provider;
  */
 async function getAppData(appExport: AppExport, requestContext?: RequestContext): Promise<AppData> {
   const hasGlobalLoader = typeof window !== 'undefined' && (window as any).__ICE_DATA_LOADER__;
+  const globalLoader = hasGlobalLoader ? (window as any).__ICE_DATA_LOADER__ : null;
 
-  if (hasGlobalLoader) {
-    const load = (window as any).__ICE_DATA_LOADER__;
-    return await load('__app');
+  if (globalLoader.hasLoad('__app')) {
+    return await globalLoader.getData('__app');
   }
 
   if (appExport?.getAppData) {

--- a/packages/runtime/src/AppData.tsx
+++ b/packages/runtime/src/AppData.tsx
@@ -19,7 +19,7 @@ async function getAppData(appExport: AppExport, requestContext?: RequestContext)
   const hasGlobalLoader = typeof window !== 'undefined' && (window as any).__ICE_DATA_LOADER__;
   const globalLoader = hasGlobalLoader ? (window as any).__ICE_DATA_LOADER__ : null;
 
-  if (globalLoader.hasLoad('__app')) {
+  if (globalLoader && globalLoader.hasLoad('__app')) {
     return await globalLoader.getData('__app');
   }
 

--- a/packages/runtime/src/RouteContext.ts
+++ b/packages/runtime/src/RouteContext.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { RouteData, RouteConfig, DataLoaderConfig } from './types.js';
+import type { RouteData, RouteConfig } from './types.js';
 
 const DataContext = React.createContext<RouteData | undefined>(undefined);
 DataContext.displayName = 'Data';
@@ -19,24 +19,9 @@ function useConfig<T = {}>(): RouteConfig<T> {
 }
 const ConfigProvider = ConfigContext.Provider;
 
-function defineDataLoader(dataLoaderConfig: DataLoaderConfig): DataLoaderConfig {
-  return dataLoaderConfig;
-}
-
-function defineServerDataLoader(dataLoaderConfig: DataLoaderConfig): DataLoaderConfig {
-  return dataLoaderConfig;
-}
-
-function defineStaticDataLoader(dataLoaderConfig: DataLoaderConfig): DataLoaderConfig {
-  return dataLoaderConfig;
-}
-
 export {
   useData,
   DataProvider,
   useConfig,
   ConfigProvider,
-  defineDataLoader,
-  defineServerDataLoader,
-  defineStaticDataLoader,
 };

--- a/packages/runtime/src/dataLoader.ts
+++ b/packages/runtime/src/dataLoader.ts
@@ -11,6 +11,18 @@ interface Result {
   status: string;
 }
 
+export function defineDataLoader(dataLoaderConfig: DataLoaderConfig): DataLoaderConfig {
+  return dataLoaderConfig;
+}
+
+export function defineServerDataLoader(dataLoaderConfig: DataLoaderConfig): DataLoaderConfig {
+  return dataLoaderConfig;
+}
+
+export function defineStaticDataLoader(dataLoaderConfig: DataLoaderConfig): DataLoaderConfig {
+  return dataLoaderConfig;
+}
+
 const cache = new Map<string, Result>();
 
 /**

--- a/packages/runtime/src/dataLoader.ts
+++ b/packages/runtime/src/dataLoader.ts
@@ -1,9 +1,9 @@
-import type { DataLoader, DataLoaderConfig, RuntimeModules, AppExport, RuntimePlugin, CommonJsRuntime } from './types.js';
+import type { DataLoaderConfig, RuntimeModules, AppExport, RuntimePlugin, CommonJsRuntime } from './types.js';
 import getRequestContext from './requestContext.js';
+import { setFetcher, loadDataByCustomFetcher } from './dataLoaderFetcher.js';
 
-type Loaders = Array<DataLoader> | DataLoader;
-interface RouteIdToLoaders {
-  [routeId: string]: Loaders;
+interface Loaders {
+  [routeId: string]: DataLoaderConfig;
 }
 
 interface Result {
@@ -11,167 +11,72 @@ interface Result {
   status: string;
 }
 
-export interface RouteIdToLoaderConfigs {
-  [routeId: string]: DataLoaderConfig;
-}
-
-let routeIdToLoaders: RouteIdToLoaders = {};
-
 const cache = new Map<string, Result>();
 
 /**
- * Get cache id by route id and number.
+ * Start getData once loader is ready, and set to cache.
  */
-function getCacheId(routeId: string, number?: Number) {
-  return number ? `${routeId}-${number}` : routeId;
-}
+function loadInitialData(loaders: Loaders) {
+  const context = (window as any).__ICE_APP_CONTEXT__ || {};
+  const matchedIds = context.matchedIds || [];
+  const routesData = context.routesData || {};
 
-/**
- * Load data by route id and set to cache.
- */
-async function loadDataByRouteId(routeId: string) {
-  if (typeof window !== 'undefined') {
-    // Try get data from ssr.
-    const context = (window as any).__ICE_APP_CONTEXT__ || {};
-    const routesData = context.routesData || {};
-
-    const dataFromSSR = routesData[routeId];
+  matchedIds.forEach(id => {
+    const dataFromSSR = routesData[id];
     if (dataFromSSR) {
-      cache.set(routeId, {
+      cache.set(id, {
         value: dataFromSSR,
         status: 'RESOLVED',
       });
 
       return dataFromSSR;
     }
-  }
 
-  async function runLoaderSaveCache(loader?: DataLoader, index?: Number) {
-    if (!loader) return;
+    const dataLoader = loaders[id];
 
-    const cacheId = getCacheId(routeId, index);
+    if (dataLoader) {
+      const requestContext = getRequestContext(window.location);
 
-    // Try get data from cache when CSR.
-    if (typeof window !== 'undefined' && cache.has(cacheId)) {
-      const { value, status } = cache.get(cacheId);
+      let loader;
 
-      if (status === 'RESOLVED') {
-        return value;
+      if (Array.isArray(dataLoader)) {
+        loader = dataLoader.map(loader => {
+          if (typeof loader === 'object') {
+            return loadDataByCustomFetcher(loader);
+          }
+
+          return loader(requestContext);
+        });
+      } else if (typeof dataLoader === 'object') {
+        return loadDataByCustomFetcher(loader);
+      } else {
+        loader = dataLoader(requestContext);
       }
 
-      if (status === 'REJECTED') {
-        throw value;
-      }
-
-      // PENDING
-      return await value;
-    }
-    const res = loader(typeof window !== 'undefined' && getRequestContext(window.location));
-    if (res instanceof Promise) {
-      res.then(data => {
-        cache.set(cacheId, {
-          value: data,
-          status: 'RESOLVED',
-        });
-        return data;
-      }).catch(err => {
-        cache.set(cacheId, {
-          value: err,
-          status: 'REJECTED',
-        });
-      });
-
-      cache.set(cacheId, {
-        value: res,
-        status: 'PENDING',
-      });
-    } else {
-      cache.set(cacheId, {
-        value: res,
-        status: 'RESOLVED',
+      cache.set(id, {
+        value: loader,
+        status: 'LOADING',
       });
     }
-
-    return res;
-  }
-
-  const loaders: Loaders = routeIdToLoaders[routeId];
-  if (Array.isArray(loaders)) {
-    return Promise.all(loaders.map(runLoaderSaveCache));
-  } else {
-    return runLoaderSaveCache(loaders);
-  }
-}
-
-/**
- * Load data from cache or fetch it.
- */
-function loadData() {
-  const context = (window as any).__ICE_APP_CONTEXT__ || {};
-  const matchedIds = context.matchedIds || [];
-
-  matchedIds.forEach(routeId => {
-    loadDataByRouteId(routeId);
   });
 }
 
-/**
- * Get loaders by config of loaders.
- */
-function getLoaders(loadersConfig: RouteIdToLoaderConfigs, dataLoaderFetcher: Function): RouteIdToLoaders {
-  function getDataLoaderByConfig(config: DataLoaderConfig): DataLoader {
-    // If dataLoader is an object, it is wrapped with a function.
-    return typeof config === 'function' ? config : () => {
-      return dataLoaderFetcher(config);
-    };
-  }
-
-  const loaders: RouteIdToLoaders = {};
-  Object.keys(loadersConfig).forEach(id => {
-    const loaderConfig: DataLoaderConfig = loadersConfig[id];
-    if (!loaderConfig) return;
-
-    if (Array.isArray(loaderConfig)) {
-      loaders[id] = loaderConfig.map((config: DataLoader) => {
-        return getDataLoaderByConfig(config);
-      });
-    } else {
-      loaders[id] = getDataLoaderByConfig(loaderConfig);
-    }
-  });
-
-  return loaders;
-}
-
-function defaultDataLoaderFetcher(options: any) {
-  return window.fetch(options.key, options);
-}
-
-export interface DataLoaderInitOptions {
-  dataLoaderFetcher?: Function;
-  needLoadData?: boolean;
-  runtimeModules?: RuntimeModules['statics'];
-  appExport?: AppExport;
+interface Options {
+  fetcher: Function;
+  runtimeModules: RuntimeModules['statics'];
+  appExport: AppExport;
 }
 
 /**
  * Load initial data and register global loader.
  * In order to load data, JavaScript modules, CSS and other assets in parallel.
  */
-async function init(loaders: RouteIdToLoaderConfigs, options?: DataLoaderInitOptions) {
+async function init(loadersConfig: Loaders, options: Options) {
   const {
-    dataLoaderFetcher = defaultDataLoaderFetcher,
-    needLoadData = false,
+    fetcher,
     runtimeModules,
     appExport,
-  } = options || {};
-
-  // Clear cache when loaders changed.
-  Object.keys(loaders).forEach(routeId => {
-    cache.delete(routeId);
-  });
-
-  routeIdToLoaders = getLoaders(loaders, dataLoaderFetcher);
+  } = options;
 
   const runtimeApi = {
     appContext: {
@@ -186,21 +91,42 @@ async function init(loaders: RouteIdToLoaderConfigs, options?: DataLoaderInitOpt
     }).filter(Boolean));
   }
 
-  if (needLoadData) {
-    try {
-      loadData();
-    } catch (error) {
-      console.error('Load initial data error: ', error);
-    }
+  if (fetcher) {
+    setFetcher(fetcher);
   }
 
-  typeof window !== 'undefined' && ((window as any).__ICE_DATA_LOADER__ = async (routeId) => {
-    return await loadDataByRouteId(routeId);
-  });
+  try {
+    loadInitialData(loadersConfig);
+  } catch (error) {
+    console.error('Load initial data error: ', error);
+  }
+
+  (window as any).__ICE_DATA_LOADER__ = {
+    hasLoad: (id) => {
+      return cache.get(id);
+    },
+    getData: async (id) => {
+      const result = cache.get(id);
+
+      if (!result) {
+        return null;
+      }
+
+      const { status, value } = result;
+
+      if (status === 'RESOLVED') {
+        return result;
+      }
+
+      if (Array.isArray(value)) {
+        return await Promise.all(value);
+      }
+
+      return await value;
+    },
+  };
 }
 
 export default {
   init,
-  loadData,
-  loadDataByRouteId,
 };

--- a/packages/runtime/src/dataLoaderFetcher.ts
+++ b/packages/runtime/src/dataLoaderFetcher.ts
@@ -1,0 +1,14 @@
+/**
+ * custom fetcher for load static data loader config
+ * set globally to avoid passing this fetcher too deep
+ */
+
+let fetcher;
+
+export function setFetcher(customFetcher) {
+  fetcher = customFetcher;
+}
+
+export function loadDataByCustomFetcher(config) {
+  return fetcher(config);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -25,7 +25,7 @@ import runClientApp from './runClientApp.js';
 import type { RunClientAppOptions } from './runClientApp.js';
 import { useAppContext, AppContextProvider } from './AppContext.js';
 import { useAppData, AppDataProvider, getAppData } from './AppData.js';
-import { useData, defineDataLoader, defineServerDataLoader, defineStaticDataLoader, useConfig, DataProvider, ConfigProvider } from './RouteContext.js';
+import { useData, useConfig, DataProvider, ConfigProvider } from './RouteContext.js';
 import {
   Meta,
   Title,
@@ -34,7 +34,7 @@ import {
   Main,
   Data,
 } from './Document.js';
-import dataLoader from './dataLoader.js';
+import dataLoader, { defineDataLoader, defineServerDataLoader, defineStaticDataLoader } from './dataLoader.js';
 import AppRouter from './AppRouter.js';
 import AppErrorBoundary from './AppErrorBoundary.js';
 import getAppConfig, { defineAppConfig } from './appConfig.js';

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -58,7 +58,7 @@ export async function loadRoutesData(
     matches.map(async (match) => {
       const { id } = match.route;
 
-      if (globalLoader.hasLoad(id)) {
+      if (globalLoader && globalLoader.hasLoad(id)) {
         routesData[id] = await globalLoader.getData(id);
         return;
       }

--- a/packages/runtime/src/routes.tsx
+++ b/packages/runtime/src/routes.tsx
@@ -39,9 +39,6 @@ export interface LoadRoutesDataOptions {
   renderMode?: RenderMode;
 }
 
-const hasGlobalLoader = typeof window !== 'undefined' && (window as any).__ICE_DATA_LOADER__;
-const globalLoader = hasGlobalLoader ? (window as any).__ICE_DATA_LOADER__ : null;
-
 /**
 * get data for the matched routes.
 */
@@ -53,6 +50,9 @@ export async function loadRoutesData(
 ): Promise<RoutesData> {
   const { renderMode } = options || {};
   const routesData: RoutesData = {};
+
+  const hasGlobalLoader = typeof window !== 'undefined' && (window as any).__ICE_DATA_LOADER__;
+  const globalLoader = hasGlobalLoader ? (window as any).__ICE_DATA_LOADER__ : null;
 
   await Promise.all(
     matches.map(async (match) => {

--- a/packages/runtime/tests/routes.test.tsx
+++ b/packages/runtime/tests/routes.test.tsx
@@ -165,14 +165,17 @@ describe('routes', () => {
 
   it('load data from __ICE_DATA_LOADER__', async () => {
     windowSpy.mockImplementation(() => ({
-      __ICE_DATA_LOADER__: async (id) => ({ id: `${id}_data` }),
+      __ICE_DATA_LOADER__: {
+        hasLoad: () => true,
+        getData: async (id) => ({ id: `${id}_data` }),
+      },
     }));
     const routesData = await loadRoutesData(
       // @ts-ignore
       [{ route: routeModules[0] }],
       {},
       {},
-      'SSG',
+      { renderMode: 'SSG' },
     );
     expect(routesData).toStrictEqual({
       home: {

--- a/packages/runtime/tests/runClientApp.test.tsx
+++ b/packages/runtime/tests/runClientApp.test.tsx
@@ -276,9 +276,12 @@ describe('run client app', () => {
     let executed = false;
     windowSpy.mockImplementation(() => ({
       ...mockData,
-      __ICE_DATA_LOADER__: async () => {
-        useGlobalLoader = true;
-        return { msg: '-globalData' };
+      __ICE_DATA_LOADER__: {
+        hasLoad: () => true,
+        getData: async () => {
+          useGlobalLoader = true;
+          return { msg: '-globalData' };
+        },
       },
     }));
 

--- a/tests/integration/basic-project.test.ts
+++ b/tests/integration/basic-project.test.ts
@@ -35,13 +35,13 @@ describe(`build ${example}`, () => {
     expect(fs.existsSync(path.join(__dirname, `../../examples/${example}/build/js/data-loader.js`))).toBe(true);
     const jsonContent = fs.readFileSync(path.join(__dirname, `../../examples/${example}/build/assets-manifest.json`), 'utf-8');
     expect(JSON.parse(jsonContent).pages.about.includes('js/framework.js')).toBeFalsy();
-    // const dataLoaderPath = path.join(__dirname, `../../examples/${example}/build/js/data-loader.js`);
+    const dataLoaderPath = path.join(__dirname, `../../examples/${example}/build/js/data-loader.js`);
     // should not contain react
-    // const dataLoaderContent = fs.readFileSync(dataLoaderPath, 'utf-8');
-    // expect(dataLoaderContent.includes('createElement')).toBe(false);
+    const dataLoaderContent = fs.readFileSync(dataLoaderPath, 'utf-8');
+    expect(dataLoaderContent.includes('createElement')).toBe(false);
     // size of data loader should be less than 14kib
-    // const stats = fs.statSync(dataLoaderPath);
-    // expect(stats.size).toBeLessThan(1024 * 14);
+    const stats = fs.statSync(dataLoaderPath);
+    expect(stats.size).toBeLessThan(1024 * 14);
   }, 120000);
 
   test('ClientOnly Component', async () => {


### PR DESCRIPTION
- dataLoader.ts 文件中只保留了 CSR 时，初始化数据请求的逻辑，避免增加太多的环境判断，及透传不同环境下 context 的问题
- 在 data-loader.js 和常规的数据请求中，各增加了对静态配置的判断
- 修复 data-loader.js 构建了 react 的问题